### PR TITLE
chore: specify module for doctypes

### DIFF
--- a/ferum_custom/doctype/custom_attachment/custom_attachment.json
+++ b/ferum_custom/doctype/custom_attachment/custom_attachment.json
@@ -1,6 +1,7 @@
 {
   "name": "CustomAttachment",
   "doctype": "DocType",
+  "module": "Ferum Custom",
   "autoname": "CA-.####",
   "fields": [
     {

--- a/ferum_custom/doctype/maintenance_schedule/maintenance_schedule.json
+++ b/ferum_custom/doctype/maintenance_schedule/maintenance_schedule.json
@@ -1,6 +1,7 @@
 {
   "name": "MaintenanceSchedule",
   "doctype": "DocType",
+  "module": "Ferum Custom",
   "autoname": "MSCH-.####",
   "is_submittable": 0,
   "fields": [

--- a/ferum_custom/doctype/maintenance_schedule_item/maintenance_schedule_item.json
+++ b/ferum_custom/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -1,6 +1,7 @@
 {
   "name": "MaintenanceScheduleItem",
   "doctype": "DocType",
+  "module": "Ferum Custom",
   "is_submittable": 0,
   "istable": 1,
   "fields": [

--- a/ferum_custom/doctype/payroll_entry_custom/payroll_entry_custom.json
+++ b/ferum_custom/doctype/payroll_entry_custom/payroll_entry_custom.json
@@ -1,6 +1,7 @@
 {
   "name": "PayrollEntryCustom",
   "doctype": "DocType",
+  "module": "Ferum Custom",
   "autoname": "PEC-.####",
   "is_submittable": 1,
   "fields": [

--- a/ferum_custom/doctype/payroll_entry_item/payroll_entry_item.json
+++ b/ferum_custom/doctype/payroll_entry_item/payroll_entry_item.json
@@ -1,6 +1,7 @@
 {
   "name": "PayrollEntryItem",
   "doctype": "DocType",
+  "module": "Ferum Custom",
   "is_submittable": 0,
   "istable": 1,
   "fields": [

--- a/ferum_custom/doctype/request_photo_attachment_item/request_photo_attachment_item.json
+++ b/ferum_custom/doctype/request_photo_attachment_item/request_photo_attachment_item.json
@@ -1,6 +1,7 @@
 {
   "name": "RequestPhotoAttachmentItem",
   "doctype": "DocType",
+  "module": "Ferum Custom",
   "is_submittable": 0,
   "istable": 1,
   "fields": [

--- a/ferum_custom/doctype/service_object/service_object.json
+++ b/ferum_custom/doctype/service_object/service_object.json
@@ -1,6 +1,7 @@
 {
   "name": "ServiceObject",
   "doctype": "DocType",
+  "module": "Ferum Custom",
   "autoname": "field:object_name",
   "fields": [
     {

--- a/ferum_custom/doctype/service_report/service_report.json
+++ b/ferum_custom/doctype/service_report/service_report.json
@@ -1,6 +1,7 @@
 {
   "name": "ServiceReport",
   "doctype": "DocType",
+  "module": "Ferum Custom",
   "autoname": "SRPT-.####",
   "is_submittable": 1,
   "fields": [

--- a/ferum_custom/doctype/service_report_document_item/service_report_document_item.json
+++ b/ferum_custom/doctype/service_report_document_item/service_report_document_item.json
@@ -1,6 +1,7 @@
 {
   "name": "ServiceReportDocumentItem",
   "doctype": "DocType",
+  "module": "Ferum Custom",
   "is_submittable": 0,
   "istable": 1,
   "fields": [

--- a/ferum_custom/doctype/service_report_work_item/service_report_work_item.json
+++ b/ferum_custom/doctype/service_report_work_item/service_report_work_item.json
@@ -1,6 +1,7 @@
 {
   "name": "ServiceReportWorkItem",
   "doctype": "DocType",
+  "module": "Ferum Custom",
   "is_submittable": 0,
   "istable": 1,
   "fields": [

--- a/ferum_custom/modules.txt
+++ b/ferum_custom/modules.txt
@@ -1,0 +1,1 @@
+Ferum Custom


### PR DESCRIPTION
## Summary
- define Ferum Custom module in modules.txt
- add explicit module reference to all DocType JSON files

## Testing
- `ruff check .`
- `pytest -q` *(fails: No module named 'frappe.tests')*


------
https://chatgpt.com/codex/tasks/task_e_68b5d5eec7e88328b92e5f904fde59ff