### PR TITLE
fix module version configuration

### DIFF
--- a/ferum_custom/__init__.py
+++ b/ferum_custom/__init__.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+	__version__ = version("ferum_custom")
+except PackageNotFoundError:
+	__version__ = "0.0.0"
+
+__all__ = ["__version__"]


### PR DESCRIPTION
## Summary
- add __version__ with importlib.metadata fallback

## Testing
- `ruff check ferum_custom/__init__.py`
- `python -m build`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*


------
https://chatgpt.com/codex/tasks/task_e_68b5d88b1a088328821946537b4494b2