### PR TITLE
chore(ci): install generic mariadb client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,9 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install MariaDB Client
-        run: sudo apt-get install mariadb-client-10.6
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mariadb-client
 
       - name: Setup
         run: |


### PR DESCRIPTION
## Summary
- install generic MariaDB client on Ubuntu runners

## Testing
- `python3 -m pre_commit run --files .github/workflows/ci.yml`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68b6118153188328b46499d08e043809