### PR TITLE
Default ServiceReport date via before_insert

### DIFF
--- a/ferum_custom/ferum_custom/doctype/service_report/service_report.json
+++ b/ferum_custom/ferum_custom/doctype/service_report/service_report.json
@@ -16,8 +16,7 @@
       "fieldname": "report_date",
       "fieldtype": "Date",
       "label": "Report Date",
-      "reqd": 1,
-      "default": "today"
+      "reqd": 1
     },
     {
       "fieldname": "status",

--- a/ferum_custom/ferum_custom/doctype/service_report/service_report.py
+++ b/ferum_custom/ferum_custom/doctype/service_report/service_report.py
@@ -4,6 +4,10 @@ from frappe.model.document import Document
 
 
 class ServiceReport(Document):
+	def before_insert(self):
+		if not self.report_date:
+			self.report_date = frappe.utils.today()
+
 	def validate(self):
 		self.calculate_total_amount()
 		self.validate_attachments()


### PR DESCRIPTION
## Summary
- remove schema default for ServiceReport report_date
- auto-populate report_date with today's date on insert

## Testing
- `pre-commit run --files ferum_custom/ferum_custom/doctype/service_report/service_report.py ferum_custom/ferum_custom/doctype/service_report/service_report.json`


------
https://chatgpt.com/codex/tasks/task_e_68b61493472883289d21df8277595727