### PR TITLE
feat: add targeted notifications for key documents

### DIFF
--- a/ferum_custom/ferum_custom/doctype/invoice/invoice.py
+++ b/ferum_custom/ferum_custom/doctype/invoice/invoice.py
@@ -12,10 +12,11 @@ except Exception:
 	gspread = None  # Optional dependency; handled at runtime
 from frappe.model.document import Document
 from frappe.utils.background_jobs import enqueue
+
 try:
-    from frappe.model.workflow import apply_workflow  # type: ignore[import-not-found]
+	from frappe.model.workflow import apply_workflow  # type: ignore[import-not-found]
 except Exception:
-    apply_workflow = None  # type: ignore[assignment]
+	apply_workflow = None  # type: ignore[assignment]
 
 try:
 	from google.oauth2.service_account import Credentials  # type: ignore[import-untyped]
@@ -56,7 +57,10 @@ def get_google_sheet():
 
 try:
 	from backend.bot.telegram_bot import send_telegram_message  # type: ignore[import-not-found]
+
+	TELEGRAM_AVAILABLE = True
 except Exception:
+	TELEGRAM_AVAILABLE = False
 
 	def send_telegram_message(*args, **kwargs):  # fallback no-op
 		try:
@@ -83,7 +87,30 @@ class Invoice(Document):
 	def notify_on_subcontractor_invoice(self):
 		if self.counterparty_type == "Subcontractor":
 			message = f"New subcontractor invoice created: {self.name} for {self.counterparty_name}. Amount: {self.amount}"
-			send_telegram_message(message)
+			if TELEGRAM_AVAILABLE:
+				try:
+					send_telegram_message(message)
+					return
+				except Exception:
+					frappe.log_error(frappe.get_traceback(), "Telegram Notification Failed")
+
+			recipients: set[str] = set()
+			roles = ["Chief Accountant", "System Manager"]
+			users = frappe.get_all(
+				"Has Role", filters={"role": ["in", roles], "parenttype": "User"}, fields=["parent"]
+			)
+			for u in users:
+				email = frappe.db.get_value("User", u.parent, "email") or u.parent
+				if email:
+					recipients.add(email)
+			if recipients:
+				frappe.sendmail(
+					recipients=list(recipients),
+					subject=_("New subcontractor invoice {0}").format(self.name),
+					message=message,
+				)
+			else:
+				frappe.log_error(message, "Subcontractor Invoice Notification")
 
 
 @frappe.whitelist()
@@ -132,116 +159,116 @@ def on_invoice_update(doc, method):
 
 @frappe.whitelist()
 def bulk_mark_sent(names: list[str] | str) -> dict:
-    """Bulk mark selected Invoices as 'Sent'.
+	"""Bulk mark selected Invoices as 'Sent'.
 
-    - Validates roles (System Manager, Project Manager, Office Manager, Chief Accountant)
-    - Skips invoices already Paid or Cancelled
-    - Returns a summary dict with updated and skipped lists
-    """
-    # Parse names when called from JS (stringified JSON or CSV)
-    if isinstance(names, str):
-        try:
-            names = frappe.parse_json(names)  # type: ignore[assignment]
-        except Exception:
-            names = [n.strip() for n in names.split(",") if n.strip()]
+	- Validates roles (System Manager, Project Manager, Office Manager, Chief Accountant)
+	- Skips invoices already Paid or Cancelled
+	- Returns a summary dict with updated and skipped lists
+	"""
+	# Parse names when called from JS (stringified JSON or CSV)
+	if isinstance(names, str):
+		try:
+			names = frappe.parse_json(names)  # type: ignore[assignment]
+		except Exception:
+			names = [n.strip() for n in names.split(",") if n.strip()]
 
-    if not names:
-        return {"updated": [], "skipped": ["<empty>"]}
+	if not names:
+		return {"updated": [], "skipped": ["<empty>"]}
 
-    roles = set(frappe.get_roles())
-    allowed_roles = {"System Manager", "Project Manager", "Office Manager", "Chief Accountant"}
-    if not roles.intersection(allowed_roles):
-        frappe.throw(_("Not permitted to change invoice status."))
+	roles = set(frappe.get_roles())
+	allowed_roles = {"System Manager", "Project Manager", "Office Manager", "Chief Accountant"}
+	if not roles.intersection(allowed_roles):
+		frappe.throw(_("Not permitted to change invoice status."))
 
-    updated: list[str] = []
-    skipped: list[str] = []
+	updated: list[str] = []
+	skipped: list[str] = []
 
-    for name in names:  # type: ignore[assignment]
-        try:
-            doc = frappe.get_doc("Invoice", name)
-            if doc.status in ("Paid", "Cancelled"):
-                skipped.append(name)
-                continue
-            if doc.status == "Sent":
-                skipped.append(name)
-                continue
-            # Prefer workflow transition if configured
-            transitioned = False
-            if apply_workflow:
-                try:
-                    apply_workflow(doc, "Send")
-                    transitioned = True
-                except Exception:
-                    transitioned = False
-            if not transitioned:
-                doc.db_set("status", "Sent")
-            updated.append(name)
-        except Exception:
-            skipped.append(name)
+	for name in names:  # type: ignore[assignment]
+		try:
+			doc = frappe.get_doc("Invoice", name)
+			if doc.status in ("Paid", "Cancelled"):
+				skipped.append(name)
+				continue
+			if doc.status == "Sent":
+				skipped.append(name)
+				continue
+			# Prefer workflow transition if configured
+			transitioned = False
+			if apply_workflow:
+				try:
+					apply_workflow(doc, "Send")
+					transitioned = True
+				except Exception:
+					transitioned = False
+			if not transitioned:
+				doc.db_set("status", "Sent")
+			updated.append(name)
+		except Exception:
+			skipped.append(name)
 
-    return {"updated": updated, "skipped": skipped}
+	return {"updated": updated, "skipped": skipped}
 
 
 @frappe.whitelist()
 def bulk_mark_paid(names: list[str] | str) -> dict:
-    """Bulk mark selected Invoices as 'Paid' using Workflow when available.
+	"""Bulk mark selected Invoices as 'Paid' using Workflow when available.
 
-    - Only Chief Accountant (and System Manager) may perform this action
-    - Requires invoices to not be Cancelled; prefers current status 'Sent'
-    - Uses workflow action 'Mark Paid' if configured; otherwise submits + sets status
-    - Returns a summary dict with updated and skipped lists
-    """
-    # Parse names when called from JS
-    if isinstance(names, str):
-        try:
-            names = frappe.parse_json(names)  # type: ignore[assignment]
-        except Exception:
-            names = [n.strip() for n in names.split(",") if n.strip()]
+	- Only Chief Accountant (and System Manager) may perform this action
+	- Requires invoices to not be Cancelled; prefers current status 'Sent'
+	- Uses workflow action 'Mark Paid' if configured; otherwise submits + sets status
+	- Returns a summary dict with updated and skipped lists
+	"""
+	# Parse names when called from JS
+	if isinstance(names, str):
+		try:
+			names = frappe.parse_json(names)  # type: ignore[assignment]
+		except Exception:
+			names = [n.strip() for n in names.split(",") if n.strip()]
 
-    if not names:
-        return {"updated": [], "skipped": ["<empty>"]}
+	if not names:
+		return {"updated": [], "skipped": ["<empty>"]}
 
-    roles = set(frappe.get_roles())
-    allowed_roles = {"Chief Accountant", "System Manager"}
-    if not roles.intersection(allowed_roles):
-        frappe.throw(_("Not permitted to mark invoices as Paid."))
+	roles = set(frappe.get_roles())
+	allowed_roles = {"Chief Accountant", "System Manager"}
+	if not roles.intersection(allowed_roles):
+		frappe.throw(_("Not permitted to mark invoices as Paid."))
 
-    updated: list[str] = []
-    skipped: list[str] = []
+	updated: list[str] = []
+	skipped: list[str] = []
 
-    for name in names:  # type: ignore[assignment]
-        try:
-            doc = frappe.get_doc("Invoice", name)
-            if doc.status in ("Paid", "Cancelled"):
-                skipped.append(name)
-                continue
+	for name in names:  # type: ignore[assignment]
+		try:
+			doc = frappe.get_doc("Invoice", name)
+			if doc.status in ("Paid", "Cancelled"):
+				skipped.append(name)
+				continue
 
-            # Prefer workflow transition if configured
-            transitioned = False
-            if apply_workflow:
-                try:
-                    apply_workflow(doc, "Mark Paid")
-                    transitioned = True
-                except Exception:
-                    transitioned = False
+			# Prefer workflow transition if configured
+			transitioned = False
+			if apply_workflow:
+				try:
+					apply_workflow(doc, "Mark Paid")
+					transitioned = True
+				except Exception:
+					transitioned = False
 
-            if not transitioned:
-                # Fallback: ensure submitted + set status
-                if doc.docstatus == 0:
-                    doc.status = "Paid"
-                    doc.submit()  # triggers on_update hooks
-                elif doc.docstatus == 1:
-                    doc.status = "Paid"
-                    doc.save()
-                else:
-                    skipped.append(name)
-                    continue
+			if not transitioned:
+				# Fallback: ensure submitted + set status
+				if doc.docstatus == 0:
+					doc.status = "Paid"
+					doc.submit()  # triggers on_update hooks
+				elif doc.docstatus == 1:
+					doc.status = "Paid"
+					doc.save()
+				else:
+					skipped.append(name)
+					continue
 
-            updated.append(name)
-        except Exception:
-            skipped.append(name)
+			updated.append(name)
+		except Exception:
+			skipped.append(name)
 
-    return {"updated": updated, "skipped": skipped}
+	return {"updated": updated, "skipped": skipped}
 
 
 @frappe.whitelist()

--- a/ferum_custom/ferum_custom/doctype/service_request/service_request.py
+++ b/ferum_custom/ferum_custom/doctype/service_request/service_request.py
@@ -7,6 +7,15 @@ from frappe.utils import add_days, add_to_date, getdate, nowdate
 
 
 class ServiceRequest(Document):
+	def after_insert(self) -> None:
+		"""Notify the project manager about the new request.
+
+		Using server-side logic ensures that only the manager of the
+		linked project receives the email instead of broadcasting to all
+		users with the Project Manager role.
+		"""
+		self.notify_project_manager()
+
 	def validate(self):
 		self.set_customer_and_project()
 		self.validate_workflow_transitions()
@@ -86,6 +95,29 @@ class ServiceRequest(Document):
 			updated = True
 		return updated
 
+	def notify_project_manager(self) -> None:
+		"""Send an email to the project manager for the linked project."""
+		if not self.project:
+			return
+
+		try:
+			pm = frappe.db.get_value("Service Project", self.project, "project_manager")
+			if not pm:
+				return
+			email = frappe.db.get_value("User", pm, "email") or pm
+			if not email:
+				return
+			frappe.sendmail(
+				recipients=[email],
+				subject=_("New Service Request {0}").format(self.name),
+				message=_("A new service request {0} was created for your project.").format(self.name),
+			)
+		except Exception:
+			frappe.log_error(
+				frappe.get_traceback(),
+				"Service Request notification failed",
+			)
+
 
 @frappe.whitelist()
 def check_all_slas():
@@ -106,8 +138,8 @@ def send_sla_breach_notifications(service_request_name: str, message: str) -> No
 	email.
 
 	Args:
-		service_request_name: Name of the :doctype:`Service Request`.
-		message: Human-readable breach message.
+	    service_request_name: Name of the :doctype:`Service Request`.
+	    message: Human-readable breach message.
 	"""
 
 	try:

--- a/ferum_custom/fixtures/notification.json
+++ b/ferum_custom/fixtures/notification.json
@@ -1,22 +1,20 @@
 [
   {
     "doctype": "Notification",
-    "name": "New Service Request",
+    "name": "Service Request Assigned",
     "module": "Ferum Custom",
     "document_type": "Service Request",
-    "event": "New",
+    "event": "Value Change",
     "channel": "Email",
-    "subject": "{{ _('\u041d\u043e\u0432\u0430\u044f \u0437\u0430\u044f\u0432\u043a\u0430 \u043d\u0430 \u043e\u0431\u0441\u043b\u0443\u0436\u0438\u0432\u0430\u043d\u0438\u0435') }}: {{ doc.name }}",
-    "message": "<p>{{ _('\u0421\u043e\u0437\u0434\u0430\u043d\u0430 \u043d\u043e\u0432\u0430\u044f \u0437\u0430\u044f\u0432\u043a\u0430') }}.</p>\n<p><b>{{ _('\u0417\u0430\u0433\u043e\u043b\u043e\u0432\u043e\u043a') }}:</b> {{ doc.title }}<br/>\n<b>{{ _('\u041f\u0440\u043e\u0435\u043a\u0442') }}:</b> {{ doc.project or '-' }}<br/>\n<b>{{ _('\u041a\u043b\u0438\u0435\u043d\u0442') }}:</b> {{ doc.customer or '-' }}</p>",
+    "value_changed": "assigned_to",
+    "condition": "doc.assigned_to",
+    "subject": "{{ _('Назначена заявка') }}: {{ doc.name }}",
+    "message": "<p>{{ _('Вам назначена заявка') }} {{ doc.name }}.</p>\n<p><b>{{ _('Заголовок') }}:</b> {{ doc.title }}</p>",
     "enabled": 1,
     "recipients": [
       {
         "doctype": "Notification Recipient",
-        "receiver_by_role": "Project Manager"
-      },
-      {
-        "doctype": "Notification Recipient",
-        "receiver_by_role": "Service Engineer"
+        "receiver_by_document_field": "assigned_to"
       }
     ]
   },
@@ -27,8 +25,8 @@
     "document_type": "Service Report",
     "event": "Submit",
     "channel": "Email",
-    "subject": "{{ _('\u041e\u0442\u0447\u0451\u0442 \u043e\u0442\u043f\u0440\u0430\u0432\u043b\u0435\u043d') }}: {{ doc.name }}",
-    "message": "<p>{{ _('\u041e\u0442\u0447\u0451\u0442 \u043f\u043e \u0440\u0430\u0431\u043e\u0442\u0430\u043c \u043e\u0442\u043f\u0440\u0430\u0432\u043b\u0435\u043d') }}.</p>\n<p><b>{{ _('\u0417\u0430\u044f\u0432\u043a\u0430') }}:</b> {{ doc.service_request or '-' }}<br/>\n<b>{{ _('\u0414\u0430\u0442\u0430') }}:</b> {{ doc.report_date }}</p>",
+    "subject": "{{ _('Отчёт отправлен') }}: {{ doc.name }}",
+    "message": "<p>{{ _('Отчёт по работам отправлен.') }}</p>\n<p><b>{{ _('Заявка') }}:</b> {{ doc.service_request or '-' }}<br/>\n<b>{{ _('Дата') }}:</b> {{ doc.report_date }}</p>",
     "enabled": 1,
     "attach_print": 1,
     "print_format": "Service Report Simple",
@@ -52,8 +50,8 @@
     "channel": "Email",
     "value_changed": "status",
     "condition": "doc.status == 'Paid'",
-    "subject": "{{ _('\u0421\u0447\u0451\u0442 \u043e\u043f\u043b\u0430\u0447\u0435\u043d') }}: {{ doc.name }}",
-    "message": "<p>{{ _('\u0421\u0442\u0430\u0442\u0443\u0441 \u0441\u0447\u0451\u0442\u0430 \u0438\u0437\u043c\u0435\u043d\u0451\u043d \u043d\u0430 Paid') }}.</p>\n<p><b>{{ _('\u041f\u0440\u043e\u0435\u043a\u0442') }}:</b> {{ doc.project or '-' }}<br/>\n<b>{{ _('\u0421\u0443\u043c\u043c\u0430') }}:</b> {{ doc.amount }}</p>",
+    "subject": "{{ _('Счёт оплачен') }}: {{ doc.name }}",
+    "message": "<p>{{ _('Статус счёта изменён на Paid') }}.</p>\n<p><b>{{ _('Проект') }}:</b> {{ doc.project or '-' }}<br/>\n<b>{{ _('Сумма') }}:</b> {{ doc.amount }}</p>",
     "enabled": 1,
     "recipients": [
       {
@@ -65,5 +63,27 @@
         "receiver_by_role": "Project Manager"
       }
     ]
+  },
+  {
+    "doctype": "Notification",
+    "name": "New Invoice",
+    "module": "Ferum Custom",
+    "document_type": "Invoice",
+    "event": "New",
+    "channel": "Email",
+    "subject": "{{ _('Создан новый счёт') }}: {{ doc.name }}",
+    "message": "<p>{{ _('Создан новый счёт.') }}</p>\n<p><b>{{ _('Контрагент') }}:</b> {{ doc.counterparty_name }}<br/>\n<b>{{ _('Сумма') }}:</b> {{ doc.amount }}</p>",
+    "enabled": 1,
+    "recipients": [
+      {
+        "doctype": "Notification Recipient",
+        "receiver_by_role": "Chief Accountant"
+      },
+      {
+        "doctype": "Notification Recipient",
+        "receiver_by_role": "System Manager"
+      }
+    ]
   }
 ]
+


### PR DESCRIPTION
## Summary
- notify project managers directly on new Service Requests
- alert assigned engineers and accountants via document notifications
- send subcontractor invoice alerts with Telegram/email fallback

## Testing
- `pre-commit run --files ferum_custom/ferum_custom/doctype/service_request/service_request.py ferum_custom/ferum_custom/doctype/invoice/invoice.py ferum_custom/fixtures/notification.json`


------
https://chatgpt.com/codex/tasks/task_e_68c7ebb59fb083288b39e08c75b9ba5f