### PR TITLE
feat: add portal service request detail view

### DIFF
--- a/ferum_custom/www/portal/index.html
+++ b/ferum_custom/www/portal/index.html
@@ -1,33 +1,33 @@
 <template>
-	<div class="container">
-		<h2>{{ _("My Service Requests") }}</h2>
-		<div id="sr-list"></div>
-		<p><a href="/portal/new-request">{{ _("Create New Request") }}</a></p>
-	</div>
+        <div class="container">
+                <h2>{{ _("My Service Requests") }}</h2>
+                <div id="sr-list"></div>
+                <p><a href="/portal/new-request">{{ _("Create New Request") }}</a></p>
+        </div>
 </template>
 <script>
-	frappe.ready(() => {
-		frappe
-			.call({
-				method: "ferum_custom.ferum_custom.api.service.list_service_requests",
-				args: { start: 0, page_length: 20 },
-			})
-			.then((r) => {
-				const el = document.getElementById("sr-list");
-				const rows = (r.message && r.message.data) || [];
-				if (!rows.length) {
-					el.innerHTML = `<p>${__("No requests yet.")}</p>`;
-					return;
-				}
-				el.innerHTML =
-					"<ul>" +
-					rows
-						.map(
-							(x) =>
-								`<li><a href="/app/service-request/${x.name}">${x.name}</a> - ${x.title} - ${x.status}</li>`,
-						)
-						.join("") +
-					"</ul>";
-			});
-	});
+        frappe.ready(() => {
+                frappe
+                        .call({
+                                method: "ferum_custom.ferum_custom.api.service.list_service_requests",
+                                args: { start: 0, page_length: 20 },
+                        })
+                        .then((r) => {
+                                const el = document.getElementById("sr-list");
+                                const rows = (r.message && r.message.data) || [];
+                                if (!rows.length) {
+                                        el.innerHTML = `<p>${__("No requests yet.")}</p>`;
+                                        return;
+                                }
+                                el.innerHTML =
+                                        "<ul>" +
+                                        rows
+                                                .map(
+                                                        (x) =>
+                                                                `<li><a href="/portal/service-request?name=${x.name}">${x.name}</a> - ${x.title} - ${x.status}</li>`,
+                                                )
+                                                .join("") +
+                                        "</ul>";
+                        });
+        });
 </script>

--- a/ferum_custom/www/portal/new-request.html
+++ b/ferum_custom/www/portal/new-request.html
@@ -1,46 +1,45 @@
 <template>
-	<div class="container">
-		<h2>{{ _("Create Service Request") }}</h2>
-		<div>
-			<div class="mb-2">
-				<label>{{ _("Title") }}</label><input id="title" class="form-control" />
-			</div>
-			<div class="mb-2">
-				<label>{{ _("Description") }}</label
-				><textarea id="description" class="form-control"></textarea>
-			</div>
-			<div class="mb-2">
-				<label>{{ _("Service Object (optional)") }}</label>
-				<input
-					id="service_object"
-					class="form-control"
-					placeholder="{{ _('Service Object name') }}"
-				/>
-			</div>
-			<button id="submit" class="btn btn-primary">{{ _("Submit") }}</button>
-			<div id="msg" class="mt-2"></div>
-		</div>
-		<p class="mt-3"><a href="/portal">{{ _("Back to list") }}</a></p>
-	</div>
+        <div class="container">
+                <h2>{{ _("Create Service Request") }}</h2>
+                <div>
+                        <div class="mb-2">
+                                <label>{{ _("Title") }}</label><input id="title" class="form-control" />
+                        </div>
+                        <div class="mb-2">
+                                <label>{{ _("Description") }}</label><textarea id="description" class="form-control"></textarea>
+                        </div>
+                        <div class="mb-2">
+                                <label>{{ _("Service Object (optional)") }}</label>
+                                <input
+                                        id="service_object"
+                                        class="form-control"
+                                        placeholder="{{ _('Service Object name') }}"
+                                />
+                        </div>
+                        <button id="submit" class="btn btn-primary">{{ _("Submit") }}</button>
+                        <div id="msg" class="mt-2"></div>
+                </div>
+                <p class="mt-3"><a href="/portal">{{ _("Back to list") }}</a></p>
+        </div>
 </template>
 <script>
-	frappe.ready(() => {
-		document.getElementById("submit").addEventListener("click", () => {
-			const title = document.getElementById("title").value;
-			const description = document.getElementById("description").value;
-			const service_object = document.getElementById("service_object").value || null;
-			frappe
-				.call({
-					method: "ferum_custom.ferum_custom.api.service.create_service_request",
-					args: { title, description, service_object },
-				})
-				.then((r) => {
-					document.getElementById("msg").innerHTML =
-						`${__("Created:")} <a href="/app/service-request/${r.message}">${r.message}</a>`;
-				})
-				.catch((e) => {
-					document.getElementById("msg").innerText = e.message || __("Error");
-				});
-		});
-	});
+        frappe.ready(() => {
+                document.getElementById("submit").addEventListener("click", () => {
+                        const title = document.getElementById("title").value;
+                        const description = document.getElementById("description").value;
+                        const service_object = document.getElementById("service_object").value || null;
+                        frappe
+                                .call({
+                                        method: "ferum_custom.ferum_custom.api.service.create_service_request",
+                                        args: { title, description, service_object },
+                                })
+                                .then((r) => {
+                                        document.getElementById("msg").innerHTML =
+                                                `${__("Created:")} <a href="/portal/service-request?name=${r.message}">${r.message}</a>`;
+                                })
+                                .catch((e) => {
+                                        document.getElementById("msg").innerText = e.message || __("Error");
+                                });
+                });
+        });
 </script>

--- a/ferum_custom/www/portal/service-request.html
+++ b/ferum_custom/www/portal/service-request.html
@@ -1,0 +1,55 @@
+<template>
+        <div class="container">
+                <h2 id="sr-title"></h2>
+                <div id="sr-details"></div>
+                <p id="report-wrapper" style="display:none;">
+                        <a id="report-link" target="_blank">{{ _("Download Service Report") }}</a>
+                </p>
+                <p><a href="/portal">{{ _("Back to list") }}</a></p>
+        </div>
+</template>
+<script>
+        frappe.ready(() => {
+                const params = new URLSearchParams(window.location.search);
+                const name = params.get("name");
+                const detailsEl = document.getElementById("sr-details");
+                if (!name) {
+                        detailsEl.innerHTML = `<p>${__("Missing Service Request ID.")}</p>`;
+                        return;
+                }
+
+                frappe
+                        .call({
+                                method: "ferum_custom.ferum_custom.api.service.get_service_request",
+                                args: { name },
+                        })
+                        .then((r) => {
+                                const doc = r.message || {};
+                                document.getElementById("sr-title").innerText =
+                                        `${doc.name || name} - ${doc.title || ""}`;
+                                const pieces = [
+                                        `<p><strong>${__("Status")}:</strong> ${doc.status || ""}</p>`,
+                                ];
+                                if (doc.description) {
+                                        pieces.push(
+                                                `<p><strong>${__("Description")}:</strong> ${
+                                                        frappe.utils.escape_html(doc.description)
+                                                }</p>`,
+                                        );
+                                }
+                                detailsEl.innerHTML = pieces.join("\n");
+                                if (doc.linked_report) {
+                                        const reportLink = document.getElementById("report-link");
+                                        reportLink.href =
+                                                "/api/method/frappe.utils.print_format.download_pdf?doctype=" +
+                                                encodeURIComponent("Service Report") +
+                                                "&name=" +
+                                                encodeURIComponent(doc.linked_report);
+                                        document.getElementById("report-wrapper").style.display = "";
+                                }
+                        })
+                        .catch((e) => {
+                                detailsEl.innerHTML = `<p>${__("Not found.")}</p>`;
+                        });
+        });
+</script>


### PR DESCRIPTION
## Summary
- allow portal users to see service request details and linked report
- add new portal page and wire create/list pages to it

## Testing
- `pre-commit run --files ferum_custom/www/portal/index.html ferum_custom/www/portal/new-request.html ferum_custom/www/portal/service-request.html`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68c7f0d3cd2483288ad44bbf1e4133bc