### PR TITLE
feat: track project financials from invoices

### DIFF
--- a/ferum_custom/ferum_custom/doctype/invoice/invoice.py
+++ b/ferum_custom/ferum_custom/doctype/invoice/invoice.py
@@ -149,6 +149,16 @@ def sync_to_google_sheets(docname: str):
 
 
 def on_invoice_update(doc, method):
+	if doc.project:
+		try:
+			from ferum_custom.ferum_custom.doctype.service_project.service_project import (
+				update_project_financials,
+			)
+
+			update_project_financials(doc.project)
+		except Exception:
+			frappe.log_error(frappe.get_traceback(), "Project Financial Update Failed")
+
 	if doc.docstatus == 1 and doc.status == "Paid":  # Submitted and Paid
 		enqueue(
 			"ferum_custom.ferum_custom.doctype.invoice.invoice.sync_to_google_sheets",

--- a/ferum_custom/ferum_custom/doctype/service_project/service_project.json
+++ b/ferum_custom/ferum_custom/doctype/service_project/service_project.json
@@ -12,6 +12,9 @@
     "start_date",
     "end_date",
     "total_amount",
+    "income_amount",
+    "expense_amount",
+    "profit_amount",
     "project_manager",
     "service_objects_section",
     "objects",
@@ -54,6 +57,24 @@
       "fieldname": "total_amount",
       "fieldtype": "Currency",
       "label": "Contract Amount"
+    },
+    {
+      "fieldname": "income_amount",
+      "fieldtype": "Currency",
+      "label": "Total Income",
+      "read_only": 1
+    },
+    {
+      "fieldname": "expense_amount",
+      "fieldtype": "Currency",
+      "label": "Total Expenses",
+      "read_only": 1
+    },
+    {
+      "fieldname": "profit_amount",
+      "fieldtype": "Currency",
+      "label": "Profit",
+      "read_only": 1
     },
     {
       "fieldname": "project_manager",

--- a/ferum_custom/ferum_custom/doctype/service_project/service_project.py
+++ b/ferum_custom/ferum_custom/doctype/service_project/service_project.py
@@ -68,3 +68,35 @@ def has_permission(doc, user: str | None = None) -> bool:
 	if doc.owner == user:
 		return True
 	return False
+
+
+def update_project_financials(project: str) -> None:
+	"""Recalculate and store financial totals for the given Service Project."""
+	if not project:
+		return
+
+	totals = frappe.db.get_all(
+		"Invoice",
+		filters={"project": project, "docstatus": 1, "status": "Paid"},
+		fields=["counterparty_type", "sum(amount) as total"],
+		group_by="counterparty_type",
+	)
+
+	income = 0.0
+	expenses = 0.0
+	for row in totals:
+		total = row.get("total") or 0
+		if row.counterparty_type == "Customer":
+			income = total
+		elif row.counterparty_type == "Subcontractor":
+			expenses = total
+
+	frappe.db.set_value(
+		"Service Project",
+		project,
+		{
+			"income_amount": income,
+			"expense_amount": expenses,
+			"profit_amount": income - expenses,
+		},
+	)

--- a/ferum_custom/hooks.py
+++ b/ferum_custom/hooks.py
@@ -44,8 +44,8 @@ app_license = "mit"
 
 # include js in doctype views (not needed for standard doctype controllers)
 doctype_js = {
-    # Keep User.user_type consistent with assigned roles (Desk vs Website)
-    "User": "public/js/user.js",
+	# Keep User.user_type consistent with assigned roles (Desk vs Website)
+	"User": "public/js/user.js",
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
@@ -213,6 +213,7 @@ scheduler_events = {
 doc_events = {
 	"Invoice": {
 		"on_update": "ferum_custom.ferum_custom.doctype.invoice.invoice.on_invoice_update",
+		"on_cancel": "ferum_custom.ferum_custom.doctype.invoice.invoice.on_invoice_update",
 	}
 }
 
@@ -285,22 +286,22 @@ fixtures = [
 		"doctype": "Report",
 		"filters": [["module", "=", "Ferum Custom"]],
 	},
-    {
-        "doctype": "Role Profile",
-        "filters": [
-            [
-                "role_profile",
-                "in",
-                [
-                    "Project Manager",
-                    "Office Manager",
-                    "Service Engineer",
-                    "Chief Accountant",
-                    "Client",
-                ],
-            ]
-        ],
-    },
+	{
+		"doctype": "Role Profile",
+		"filters": [
+			[
+				"role_profile",
+				"in",
+				[
+					"Project Manager",
+					"Office Manager",
+					"Service Engineer",
+					"Chief Accountant",
+					"Client",
+				],
+			]
+		],
+	},
 ]
 
 # Request hooks (JWT optional)


### PR DESCRIPTION
## Summary
- track project income and expenses on Service Project
- recalc project totals when invoices change
- update hooks to refresh totals on cancel

## Testing
- `pre-commit run --files ferum_custom/ferum_custom/doctype/invoice/invoice.py ferum_custom/ferum_custom/doctype/service_project/service_project.json ferum_custom/ferum_custom/doctype/service_project/service_project.py ferum_custom/hooks.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*


------
https://chatgpt.com/codex/tasks/task_e_68c7f37eb84083289ca7621b9f64e678