### PR TITLE
feat: add admin workspace and charts

### DIFF
--- a/ferum_custom/fixtures/dashboard_chart.json
+++ b/ferum_custom/fixtures/dashboard_chart.json
@@ -1,0 +1,31 @@
+[
+  {
+    "doctype": "Dashboard Chart",
+    "is_standard": 1,
+    "module": "Ferum Custom",
+    "chart_name": "Open Service Requests by Status",
+    "chart_type": "Group By",
+    "type": "Pie",
+    "document_type": "Service Request",
+    "group_by_type": "Count",
+    "group_by_based_on": "status",
+    "filters_json": "[]",
+    "is_public": 1,
+    "timeseries": 0
+  },
+  {
+    "doctype": "Dashboard Chart",
+    "is_standard": 1,
+    "module": "Ferum Custom",
+    "chart_name": "Invoices by Project",
+    "chart_type": "Group By",
+    "type": "Bar",
+    "document_type": "Invoice",
+    "group_by_type": "Sum",
+    "group_by_based_on": "project",
+    "value_based_on": "grand_total",
+    "filters_json": "[]",
+    "is_public": 1,
+    "timeseries": 0
+  }
+]

--- a/ferum_custom/hooks.py
+++ b/ferum_custom/hooks.py
@@ -6,112 +6,124 @@ app_email = "rusakov@ferumrus.ru"
 app_license = "mit"
 
 doctype_js = {
-    # Keep User.user_type consistent with assigned roles (Desk vs Website)
-    "User": "public/js/user.js",
+	# Keep User.user_type consistent with assigned roles (Desk vs Website)
+	"User": "public/js/user.js",
 }
 
 scheduler_events = {
-    "daily": [
-        "ferum_custom.ferum_custom.doctype.service_maintenance_schedule.service_maintenance_schedule.generate_service_requests_from_schedule",
-    ],
-    "hourly": [
-        "ferum_custom.ferum_custom.doctype.service_request.service_request.check_all_slas",
-    ],
+	"daily": [
+		"ferum_custom.ferum_custom.doctype.service_maintenance_schedule.service_maintenance_schedule.generate_service_requests_from_schedule",
+	],
+	"hourly": [
+		"ferum_custom.ferum_custom.doctype.service_request.service_request.check_all_slas",
+	],
 }
 
 doc_events = {
-    "Invoice": {
-        "on_update": "ferum_custom.ferum_custom.doctype.invoice.invoice.on_invoice_update",
-        "on_cancel": "ferum_custom.ferum_custom.doctype.invoice.invoice.on_invoice_update",
-    }
+	"Invoice": {
+		"on_update": "ferum_custom.ferum_custom.doctype.invoice.invoice.on_invoice_update",
+		"on_cancel": "ferum_custom.ferum_custom.doctype.invoice.invoice.on_invoice_update",
+	}
 }
 
 fixtures = [
-    {
-        "doctype": "Workflow Action Master",
-        "filters": [
-            [
-                "workflow_action_name",
-                "in",
-                [
-                    "Start Work",
-                    "Complete",
-                    "Close",
-                    "Cancel",
-                    "Submit",
-                    "Approve",
-                    "Archive",
-                    "Reopen",
-                    "Activate",
-                    "Reject",
-                    "Send",
-                    "Mark Paid",
-                ],
-            ]
-        ],
-    },
-    {
-        "doctype": "Workflow",
-        "filters": [
-            [
-                "name",
-                "in",
-                [
-                    "Service Request Workflow",
-                    "Service Report Workflow",
-                    "Service Project Workflow",
-                    "Invoice Workflow",
-                ],
-            ]
-        ],
-    },
-    {
-        "doctype": "Role",
-        "filters": [
-            [
-                "role_name",
-                "in",
-                [
-                    "Office Manager",
-                    "Chief Accountant",
-                    "Service Engineer",
-                    "Project Manager",
-                    "Client",
-                ],
-            ]
-        ],
-    },
-    {
-        "doctype": "Print Format",
-        "filters": [["module", "=", "Ferum Custom"]],
-    },
-    {
-        "doctype": "Notification",
-        "filters": [["module", "=", "Ferum Custom"]],
-    },
-    {
-        "doctype": "Report",
-        "filters": [["module", "=", "Ferum Custom"]],
-    },
-    {
-        "doctype": "Role Profile",
-        "filters": [
-            [
-                "role_profile",
-                "in",
-                [
-                    "Project Manager",
-                    "Office Manager",
-                    "Service Engineer",
-                    "Chief Accountant",
-                    "Client",
-                ],
-            ]
-        ],
-    },
+	{
+		"doctype": "Workflow Action Master",
+		"filters": [
+			[
+				"workflow_action_name",
+				"in",
+				[
+					"Start Work",
+					"Complete",
+					"Close",
+					"Cancel",
+					"Submit",
+					"Approve",
+					"Archive",
+					"Reopen",
+					"Activate",
+					"Reject",
+					"Send",
+					"Mark Paid",
+				],
+			]
+		],
+	},
+	{
+		"doctype": "Workflow",
+		"filters": [
+			[
+				"name",
+				"in",
+				[
+					"Service Request Workflow",
+					"Service Report Workflow",
+					"Service Project Workflow",
+					"Invoice Workflow",
+				],
+			]
+		],
+	},
+	{
+		"doctype": "Role",
+		"filters": [
+			[
+				"role_name",
+				"in",
+				[
+					"Office Manager",
+					"Chief Accountant",
+					"Service Engineer",
+					"Project Manager",
+					"Client",
+				],
+			]
+		],
+	},
+	{
+		"doctype": "Print Format",
+		"filters": [["module", "=", "Ferum Custom"]],
+	},
+	{
+		"doctype": "Notification",
+		"filters": [["module", "=", "Ferum Custom"]],
+	},
+	{
+		"doctype": "Report",
+		"filters": [["module", "=", "Ferum Custom"]],
+	},
+	{
+		"doctype": "Role Profile",
+		"filters": [
+			[
+				"role_profile",
+				"in",
+				[
+					"Project Manager",
+					"Office Manager",
+					"Service Engineer",
+					"Chief Accountant",
+					"Client",
+				],
+			]
+		],
+	},
+	{
+		"doctype": "Dashboard Chart",
+		"filters": [
+			[
+				"chart_name",
+				"in",
+				[
+					"Open Service Requests by Status",
+					"Invoices by Project",
+				],
+			]
+		],
+	},
 ]
 
 before_request = [
-    "ferum_custom.ferum_custom.api.auth.jwt_before_request",
+	"ferum_custom.ferum_custom.api.auth.jwt_before_request",
 ]
-

--- a/ferum_custom/workspace/administration/administration.json
+++ b/ferum_custom/workspace/administration/administration.json
@@ -1,0 +1,13 @@
+{
+  "label": "Administration",
+  "public": 1,
+  "module": "Ferum Custom",
+  "icon": "octicon octicon-graph",
+  "doctype": "Workspace",
+  "content": [
+    { "type": "chart", "chart_name": "Open Service Requests by Status" },
+    { "type": "chart", "chart_name": "Invoices by Project" },
+    { "type": "shortcut", "label": "Overdue Service Requests", "link_to": "List/Service Request?status=Overdue" },
+    { "type": "shortcut", "label": "Income Statement", "link_to": "query-report/Income Statement" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Administration workspace with shortcuts and KPI charts
- provide fixtures for dashboard charts
- include charts in app fixtures

## Testing
- `pre-commit run --files ferum_custom/workspace/administration/administration.json ferum_custom/fixtures/dashboard_chart.json ferum_custom/hooks.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*


------
https://chatgpt.com/codex/tasks/task_e_68c7f90cbed88328a6a6b43799294bec