### PR TITLE
feat: add project profitability report and workspace

### DIFF
--- a/ferum_custom/fixtures/report.json
+++ b/ferum_custom/fixtures/report.json
@@ -9,9 +9,18 @@
     "is_standard": "No",
     "query": "SELECT name, project, status, priority, assigned_to, modified FROM `tabService Request` WHERE (%(project)s IS NULL OR project = %(project)s) ORDER BY modified DESC",
     "roles": [
-      { "doctype": "Report Perm", "role": "System Manager" },
-      { "doctype": "Report Perm", "role": "Project Manager" },
-      { "doctype": "Report Perm", "role": "Office Manager" }
+      {
+        "doctype": "Report Perm",
+        "role": "System Manager"
+      },
+      {
+        "doctype": "Report Perm",
+        "role": "Project Manager"
+      },
+      {
+        "doctype": "Report Perm",
+        "role": "Office Manager"
+      }
     ]
   },
   {
@@ -24,9 +33,42 @@
     "is_standard": "No",
     "query": "SELECT name, project, counterparty_name, counterparty_type, status, amount, invoice_date, modified FROM `tabInvoice` WHERE (%(project)s IS NULL OR project = %(project)s) ORDER BY modified DESC",
     "roles": [
-      { "doctype": "Report Perm", "role": "System Manager" },
-      { "doctype": "Report Perm", "role": "Project Manager" },
-      { "doctype": "Report Perm", "role": "Chief Accountant" }
+      {
+        "doctype": "Report Perm",
+        "role": "System Manager"
+      },
+      {
+        "doctype": "Report Perm",
+        "role": "Project Manager"
+      },
+      {
+        "doctype": "Report Perm",
+        "role": "Chief Accountant"
+      }
+    ]
+  },
+  {
+    "doctype": "Report",
+    "name": "Project Profitability",
+    "report_name": "Project Profitability",
+    "ref_doctype": "Service Project",
+    "module": "Ferum Custom",
+    "report_type": "Query Report",
+    "is_standard": "No",
+    "query": "SELECT p.name AS \"Project:Link/Service Project:150\", COALESCE(SUM(CASE WHEN i.counterparty_type='Customer' AND i.status!='Cancelled' THEN i.amount END),0) AS \"Customer Invoices:Currency:150\", COALESCE(SUM(CASE WHEN i.counterparty_type='Subcontractor' AND i.status!='Cancelled' THEN i.amount END),0) AS \"Subcontractor Invoices:Currency:150\", COALESCE(SUM(CASE WHEN i.counterparty_type='Customer' AND i.status!='Cancelled' THEN i.amount END),0) - COALESCE(SUM(CASE WHEN i.counterparty_type='Subcontractor' AND i.status!='Cancelled' THEN i.amount END),0) AS \"Profit:Currency:150\" FROM `tabService Project` p LEFT JOIN `tabInvoice` i ON i.project = p.name GROUP BY p.name ORDER BY p.modified DESC",
+    "roles": [
+      {
+        "doctype": "Report Perm",
+        "role": "System Manager"
+      },
+      {
+        "doctype": "Report Perm",
+        "role": "Project Manager"
+      },
+      {
+        "doctype": "Report Perm",
+        "role": "Chief Accountant"
+      }
     ]
   }
 ]

--- a/ferum_custom/workspace/project_management/project_management.json
+++ b/ferum_custom/workspace/project_management/project_management.json
@@ -1,0 +1,19 @@
+{
+  "label": "Project Management",
+  "public": 1,
+  "module": "Ferum Custom",
+  "doctype": "Workspace",
+  "content": [
+    { "type": "shortcut", "label": "Service Projects", "link_to": "List/Service Project" },
+    { "type": "shortcut", "label": "Service Requests", "link_to": "List/Service Request" },
+    { "type": "shortcut", "label": "Service Reports", "link_to": "List/Service Report" },
+    { "type": "shortcut", "label": "Service Objects", "link_to": "List/Service Object" },
+    { "type": "shortcut", "label": "Invoices", "link_to": "List/Invoice" },
+    { "type": "shortcut", "label": "New Project", "link_to": "Form/Service Project/New Service Project" },
+    { "type": "shortcut", "label": "New Invoice (Customer)", "link_to": "Form/Invoice/New Invoice?counterparty_type=Customer" },
+    { "type": "shortcut", "label": "New Invoice (Subcontractor)", "link_to": "Form/Invoice/New Invoice?counterparty_type=Subcontractor" },
+    { "type": "shortcut", "label": "Project Profitability", "link_to": "query-report/Project Profitability" },
+    { "type": "shortcut", "label": "Service Requests by Project", "link_to": "query-report/Service Requests by Project" },
+    { "type": "shortcut", "label": "Invoices by Project", "link_to": "query-report/Invoices by Project" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Project Profitability query report summarizing customer and subcontractor invoices per project
- create Project Management workspace with links to key project documents and new reports

## Testing
- `pre-commit run --files ferum_custom/fixtures/report.json ferum_custom/workspace/project_management/project_management.json`

------
https://chatgpt.com/codex/tasks/task_e_68c8073498e883289cefde3fcff944a4