### PR TITLE
Fix N+1 email lookups in service requests and invoices

### DIFF
--- a/ferum_custom/ferum_custom/doctype/invoice/invoice.py
+++ b/ferum_custom/ferum_custom/doctype/invoice/invoice.py
@@ -96,13 +96,18 @@ class Invoice(Document):
 
 			recipients: set[str] = set()
 			roles = ["Chief Accountant", "System Manager"]
-			users = frappe.get_all(
-				"Has Role", filters={"role": ["in", roles], "parenttype": "User"}, fields=["parent"]
+			user_ids = frappe.get_all(
+				"Has Role",
+				filters={"role": ["in", roles], "parenttype": "User"},
+				pluck="parent",
 			)
-			for u in users:
-				email = frappe.db.get_value("User", u.parent, "email") or u.parent
-				if email:
-					recipients.add(email)
+			if user_ids:
+				for u in frappe.db.get_all(
+					"User",
+					filters={"name": ["in", user_ids]},
+					fields=["name", "email"],
+				):
+					recipients.add(u.email or u.name)
 			if recipients:
 				frappe.sendmail(
 					recipients=list(recipients),

--- a/ferum_custom/ferum_custom/doctype/service_request/service_request.py
+++ b/ferum_custom/ferum_custom/doctype/service_request/service_request.py
@@ -101,10 +101,15 @@ class ServiceRequest(Document):
 			return
 
 		try:
-			pm = frappe.db.get_value("Service Project", self.project, "project_manager")
-			if not pm:
+			pm_info = frappe.db.get_value(
+				"Service Project",
+				self.project,
+				["project_manager", "project_manager.email"],
+				as_dict=True,
+			)
+			if not pm_info:
 				return
-			email = frappe.db.get_value("User", pm, "email") or pm
+			email = pm_info.get("project_manager.email") or pm_info.get("project_manager")
 			if not email:
 				return
 			frappe.sendmail(
@@ -149,22 +154,30 @@ def send_sla_breach_notifications(service_request_name: str, message: str) -> No
 
 		# Project manager assigned to the related Service Project
 		if sr.project:
-			project_manager = frappe.db.get_value("Service Project", sr.project, "project_manager")
-			if project_manager:
-				pm_email = frappe.db.get_value("User", project_manager, "email") or project_manager
+			pm_info = frappe.db.get_value(
+				"Service Project",
+				sr.project,
+				["project_manager", "project_manager.email"],
+				as_dict=True,
+			)
+			if pm_info:
+				pm_email = pm_info.get("project_manager.email") or pm_info.get("project_manager")
 				if pm_email:
 					recipients.add(pm_email)
 
 		# All Office Managers in the system
-		office_managers = frappe.get_all(
+		office_manager_ids = frappe.get_all(
 			"Has Role",
-			fields=["parent"],
 			filters={"role": "Office Manager", "parenttype": "User"},
+			pluck="parent",
 		)
-		for om in office_managers:
-			om_email = frappe.db.get_value("User", om.parent, "email") or om.parent
-			if om_email:
-				recipients.add(om_email)
+		if office_manager_ids:
+			for om in frappe.db.get_all(
+				"User",
+				filters={"name": ["in", office_manager_ids]},
+				fields=["name", "email"],
+			):
+				recipients.add(om.email or om.name)
 
 		if recipients:
 			frappe.sendmail(


### PR DESCRIPTION
## Summary
- eliminate N+1 queries for project manager notifications in service requests
- batch load office and project manager emails for SLA breach alerts
- batch load notification recipients in subcontractor invoice handler

## Testing
- `python -m py_compile ferum_custom/ferum_custom/doctype/service_request/service_request.py ferum_custom/ferum_custom/doctype/invoice/invoice.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68c809ecabf08328adde7afe10d85d68