### PR TITLE
fix: handle canceled invoices and update dashboard shortcuts

### DIFF
--- a/ferum_custom/ferum_custom/doctype/invoice/invoice.py
+++ b/ferum_custom/ferum_custom/doctype/invoice/invoice.py
@@ -164,12 +164,18 @@ def on_invoice_update(doc, method):
 		except Exception:
 			frappe.log_error(frappe.get_traceback(), "Project Financial Update Failed")
 
-	if doc.docstatus == 1 and doc.status == "Paid":  # Submitted and Paid
-		enqueue(
-			"ferum_custom.ferum_custom.doctype.invoice.invoice.sync_to_google_sheets",
-			queue="short",
-			docname=doc.name,
-		)
+        if doc.docstatus == 1 and doc.status == "Paid":  # Submitted and Paid
+                enqueue(
+                        "ferum_custom.ferum_custom.doctype.invoice.invoice.sync_to_google_sheets",
+                        queue="short",
+                        docname=doc.name,
+                )
+        elif doc.docstatus == 2:  # Cancelled
+                enqueue(
+                        "ferum_custom.ferum_custom.doctype.invoice.invoice.sync_to_google_sheets",
+                        queue="short",
+                        docname=doc.name,
+                )
 
 
 @frappe.whitelist()

--- a/ferum_custom/fixtures/dashboard_chart.json
+++ b/ferum_custom/fixtures/dashboard_chart.json
@@ -23,7 +23,7 @@
     "document_type": "Invoice",
     "group_by_type": "Sum",
     "group_by_based_on": "project",
-    "value_based_on": "grand_total",
+    "value_based_on": "amount",
     "filters_json": "[]",
     "is_public": 1,
     "timeseries": 0

--- a/ferum_custom/fixtures/notification.json
+++ b/ferum_custom/fixtures/notification.json
@@ -71,6 +71,7 @@
     "document_type": "Invoice",
     "event": "New",
     "channel": "Email",
+    "condition": "doc.counterparty_type != 'Субподрядчик'",
     "subject": "{{ _('Создан новый счёт') }}: {{ doc.name }}",
     "message": "<p>{{ _('Создан новый счёт.') }}</p>\n<p><b>{{ _('Контрагент') }}:</b> {{ doc.counterparty_name }}<br/>\n<b>{{ _('Сумма') }}:</b> {{ doc.amount }}</p>",
     "enabled": 1,

--- a/ferum_custom/workspace/administration/administration.json
+++ b/ferum_custom/workspace/administration/administration.json
@@ -7,7 +7,7 @@
   "content": [
     { "type": "chart", "chart_name": "Open Service Requests by Status" },
     { "type": "chart", "chart_name": "Invoices by Project" },
-    { "type": "shortcut", "label": "Overdue Service Requests", "link_to": "List/Service Request?status=Overdue" },
+    { "type": "shortcut", "label": "Overdue Service Requests", "link_to": "List/Service Request?status=Open" },
     { "type": "shortcut", "label": "Income Statement", "link_to": "query-report/Income Statement" }
   ]
 }


### PR DESCRIPTION
## Summary
- skip subcontractor notifications for new invoices
- sync canceled invoices to Google Sheets
- adjust chart metric to amount
- point service request shortcut to open items

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe.tests')*


------
https://chatgpt.com/codex/tasks/task_e_68c80b6ed280832899d2f563ac47284c