### PR TITLE
feat: make invoice notification roles configurable

### DIFF
--- a/ferum_custom/ferum_custom/doctype/ferum_custom_settings/ferum_custom_settings.json
+++ b/ferum_custom/ferum_custom/doctype/ferum_custom_settings/ferum_custom_settings.json
@@ -67,6 +67,17 @@
       "fieldname": "jwt_secret",
       "fieldtype": "Password",
       "label": "JWT Secret"
+    },
+    {
+      "fieldname": "notification_section",
+      "fieldtype": "Section Break",
+      "label": "Notifications"
+    },
+    {
+      "fieldname": "invoice_notification_roles",
+      "fieldtype": "Table MultiSelect",
+      "label": "Invoice Notification Roles",
+      "options": "Role"
     }
   ],
   "permissions": [

--- a/ferum_custom/ferum_custom/doctype/invoice/invoice.py
+++ b/ferum_custom/ferum_custom/doctype/invoice/invoice.py
@@ -95,19 +95,24 @@ class Invoice(Document):
 					frappe.log_error(frappe.get_traceback(), "Telegram Notification Failed")
 
 			recipients: set[str] = set()
+			settings = _get_settings()
 			roles = ["Chief Accountant", "System Manager"]
-			user_ids = frappe.get_all(
-				"Has Role",
-				filters={"role": ["in", roles], "parenttype": "User"},
-				pluck="parent",
-			)
-			if user_ids:
-				for u in frappe.db.get_all(
-					"User",
-					filters={"name": ["in", user_ids]},
-					fields=["name", "email"],
-				):
-					recipients.add(u.email or u.name)
+			if settings and getattr(settings, "invoice_notification_roles", None):
+				roles = [r.role for r in settings.invoice_notification_roles]
+
+			if roles:
+				user_ids = frappe.get_all(
+					"Has Role",
+					filters={"role": ["in", roles], "parenttype": "User"},
+					pluck="parent",
+				)
+				if user_ids:
+					for u in frappe.db.get_all(
+						"User",
+						filters={"name": ["in", user_ids]},
+						fields=["name", "email"],
+					):
+						recipients.add(u.email or u.name)
 			if recipients:
 				frappe.sendmail(
 					recipients=list(recipients),
@@ -164,18 +169,18 @@ def on_invoice_update(doc, method):
 		except Exception:
 			frappe.log_error(frappe.get_traceback(), "Project Financial Update Failed")
 
-        if doc.docstatus == 1 and doc.status == "Paid":  # Submitted and Paid
-                enqueue(
-                        "ferum_custom.ferum_custom.doctype.invoice.invoice.sync_to_google_sheets",
-                        queue="short",
-                        docname=doc.name,
-                )
-        elif doc.docstatus == 2:  # Cancelled
-                enqueue(
-                        "ferum_custom.ferum_custom.doctype.invoice.invoice.sync_to_google_sheets",
-                        queue="short",
-                        docname=doc.name,
-                )
+	if doc.docstatus == 1 and doc.status == "Paid":  # Submitted and Paid
+		enqueue(
+			"ferum_custom.ferum_custom.doctype.invoice.invoice.sync_to_google_sheets",
+			queue="short",
+			docname=doc.name,
+		)
+	elif doc.docstatus == 2:  # Cancelled
+		enqueue(
+			"ferum_custom.ferum_custom.doctype.invoice.invoice.sync_to_google_sheets",
+			queue="short",
+			docname=doc.name,
+		)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Summary
- allow configuring invoice notification roles via Ferum Custom Settings
- load roles from settings instead of hardcoding in subcontractor invoice notification

## Testing
- `pre-commit run --files ferum_custom/ferum_custom/doctype/ferum_custom_settings/ferum_custom_settings.json ferum_custom/ferum_custom/doctype/invoice/invoice.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68c80c8bcbf08328b670f0d1e3301835