### PR TITLE
fix: enforce service report workflow

### DIFF
--- a/ferum_custom/ferum_custom/doctype/service_report/service_report.py
+++ b/ferum_custom/ferum_custom/doctype/service_report/service_report.py
@@ -53,12 +53,11 @@ class ServiceReport(Document):
 			("Draft", "Submitted"),
 			("Submitted", "Approved"),
 			("Approved", "Archived"),
-			("Submitted", "Draft"),
 		}
 
 		if self.status == "Cancelled":
-			if old_status not in ["Draft", "Submitted"]:
-				frappe.throw(_("Service Report can only be Cancelled from Draft or Submitted status."))
+			if old_status != "Submitted":
+				frappe.throw(_("Service Report can only be Cancelled from Submitted status."))
 			return
 
 		if not old_status or old_status == self.status:

--- a/ferum_custom/tests/test_workflows.py
+++ b/ferum_custom/tests/test_workflows.py
@@ -67,3 +67,33 @@ class TestWorkflows(FrappeTestCase):
 		sr.reload()
 		assert sr.status == "Completed"
 		assert sr.linked_report == rep.name
+
+	def test_service_report_cancel_only_from_submitted(self):
+		sr = frappe.new_doc("Service Request")
+		sr.title = "Cancel from submitted"
+		sr.type = "Routine Maintenance"
+		sr.priority = "Low"
+		sr.service_object = frappe.db.get_value("Service Object", {"object_name": "Obj-1"})
+		sr.insert()
+
+		att = frappe.new_doc("Custom Attachment")
+		att.file_name = "report.pdf"
+		att.file_url = "https://example.com/report.pdf"
+		att.insert()
+
+		rep = frappe.new_doc("Service Report")
+		rep.service_request = sr.name
+		rep.report_date = frappe.utils.nowdate()
+		rep.append("work_items", {"description": "Work", "hours": 1.0, "rate": 100})
+		rep.append("documents", {"custom_attachment": att.name})
+		rep.insert()
+
+		rep.status = "Cancelled"
+		with self.assertRaises(frappe.ValidationError):
+			rep.validate_workflow_transitions()
+
+		rep.status = "Submitted"
+		rep.save()
+
+		rep.status = "Cancelled"
+		rep.validate_workflow_transitions()


### PR DESCRIPTION
## Summary
- remove unsupported Submitted → Draft transition
- allow cancelling Service Reports only from Submitted status
- add regression test for cancel precondition

## Testing
- `pre-commit run --files ferum_custom/ferum_custom/doctype/service_report/service_report.py ferum_custom/tests/test_workflows.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68c80e61c4508328b9d8a4be0f126516