### PR TITLE
feat: add client workspace

### DIFF
--- a/ferum_custom/fixtures/role.json
+++ b/ferum_custom/fixtures/role.json
@@ -3,5 +3,5 @@
   { "doctype": "Role", "name": "Chief Accountant", "role_name": "Chief Accountant", "desk_access": 1 },
   { "doctype": "Role", "name": "Service Engineer", "role_name": "Service Engineer", "desk_access": 1 },
   { "doctype": "Role", "name": "Project Manager", "role_name": "Project Manager", "desk_access": 1 },
-  { "doctype": "Role", "name": "Client", "role_name": "Client", "desk_access": 0 }
+  { "doctype": "Role", "name": "Client", "role_name": "Client", "desk_access": 1 }
 ]

--- a/ferum_custom/patches/v1_0_0/enforce_active_workflows.py
+++ b/ferum_custom/patches/v1_0_0/enforce_active_workflows.py
@@ -1,6 +1,5 @@
 import frappe
 
-
 TARGETS = {
     "Service Request": "Service Request Workflow",
     "Service Report": "Service Report Workflow",

--- a/ferum_custom/workspace/client/client.json
+++ b/ferum_custom/workspace/client/client.json
@@ -1,0 +1,15 @@
+{
+  "label": "Client",
+  "public": 0,
+  "module": "Ferum Custom",
+  "roles": [
+    { "role": "System Manager" },
+    { "role": "Client" }
+  ],
+  "doctype": "Workspace",
+  "content": [
+    { "type": "shortcut", "label": "New Service Request", "link_to": "/portal/new-request" },
+    { "type": "shortcut", "label": "My Requests", "link_to": "List/Service Request" },
+    { "type": "shortcut", "label": "My Invoices", "link_to": "List/Invoice" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add client workspace with shortcuts for new requests, request list, and invoices
- allow desk access for Client role
- tidy workflow patch imports

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68c815bbc1d483289d8d098ed7ea8b2f