### PR TITLE
feat: add service engineer workspace

### DIFF
--- a/ferum_custom/workspace/my_requests/my_requests.json
+++ b/ferum_custom/workspace/my_requests/my_requests.json
@@ -1,0 +1,15 @@
+{
+  "label": "My Requests",
+  "public": 0,
+  "module": "Ferum Custom",
+  "roles": [
+    { "role": "Service Engineer" }
+  ],
+  "doctype": "Workspace",
+  "content": [
+    { "type": "shortcut", "label": "Service Requests", "link_to": "List/Service Request" },
+    { "type": "shortcut", "label": "My Open Requests", "link_to": "List/Service Request?status=Open&assigned_to=me" },
+    { "type": "shortcut", "label": "My Reports", "link_to": "List/Service Report" },
+    { "type": "shortcut", "label": "New Service Report", "link_to": "Form/Service Report/New Service Report" }
+  ]
+}

--- a/ferum_custom/workspace/service_operations/service_operations.json
+++ b/ferum_custom/workspace/service_operations/service_operations.json
@@ -5,7 +5,6 @@
   "roles": [
     { "role": "System Manager" },
     { "role": "Project Manager" },
-    { "role": "Service Engineer" },
     { "role": "Office Manager" }
   ],
   "doctype": "Workspace",


### PR DESCRIPTION
## Summary
- add dedicated "My Requests" workspace for Service Engineers
- remove Service Engineer role from general Service Operations workspace

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe.tests')*


------
https://chatgpt.com/codex/tasks/task_e_68c813889a108328a57a5ae2b4a3f502