### PR TITLE
Refactor SQL queries and notification utilities

### DIFF
--- a/ferum_custom/ferum_custom/doctype/custom_attachment/custom_attachment.py
+++ b/ferum_custom/ferum_custom/doctype/custom_attachment/custom_attachment.py
@@ -3,114 +3,89 @@ from frappe.model.document import Document
 
 
 def _pgc_for_custom_attachment(user: str) -> str:
-    roles = set(frappe.get_roles(user))
-    if "System Manager" in roles:
-        return None  # no restriction
+	roles = set(frappe.get_roles(user))
+	if "System Manager" in roles:
+		return None  # no restriction
 
-    conds: list[str] = []
-    # Project Manager: attachments linked to Service Reports under their projects
-    if "Project Manager" in roles:
-        conds.append(
-            "exists("
-            " select 1 from `tabService Report Document Item` srd"
-            " join `tabService Report` sr on sr.name=srd.parent"
-            " join `tabService Request` req on req.name=sr.service_request"
-            " join `tabService Project` sp on sp.name=req.project"
-            " where srd.custom_attachment=`tabCustom Attachment`.name"
-            " and sp.project_manager=%(user)s)"
-        )
-    # Service Engineer: attachments through requests assigned to user
-    if "Service Engineer" in roles:
-        conds.append(
-            "exists("
-            " select 1 from `tabService Report Document Item` srd"
-            " join `tabService Report` sr on sr.name=srd.parent"
-            " join `tabService Request` req on req.name=sr.service_request"
-            " where srd.custom_attachment=`tabCustom Attachment`.name"
-            " and req.assigned_to=%(user)s)"
-        )
-    # Client: attachments via requests owned by user
-    if "Client" in roles:
-        conds.append(
-            "exists("
-            " select 1 from `tabService Report Document Item` srd"
-            " join `tabService Report` sr on sr.name=srd.parent"
-            " join `tabService Request` req on req.name=sr.service_request"
-            " where srd.custom_attachment=`tabCustom Attachment`.name"
-            " and req.owner=%(user)s)"
-        )
-    # Office Manager / Chief Accountant: broad read access
-    if "Office Manager" in roles or "Chief Accountant" in roles:
-        # No extra filters for these roles
-        return None
+	conds: list[str] = []
+	# Project Manager: attachments linked to Service Reports under their projects
+	if "Project Manager" in roles:
+		conds.append(
+			"exists("
+			" select 1 from `tabService Report Document Item` srd"
+			" join `tabService Report` sr on sr.name=srd.parent"
+			" join `tabService Request` req on req.name=sr.service_request"
+			" join `tabService Project` sp on sp.name=req.project"
+			" where srd.custom_attachment=`tabCustom Attachment`.name"
+			" and sp.project_manager=%(user)s)"
+		)
+	# Service Engineer: attachments through requests assigned to user
+	if "Service Engineer" in roles:
+		conds.append(
+			"exists("
+			" select 1 from `tabService Report Document Item` srd"
+			" join `tabService Report` sr on sr.name=srd.parent"
+			" join `tabService Request` req on req.name=sr.service_request"
+			" where srd.custom_attachment=`tabCustom Attachment`.name"
+			" and req.assigned_to=%(user)s)"
+		)
+	# Client: attachments via requests owned by user
+	if "Client" in roles:
+		conds.append(
+			"exists("
+			" select 1 from `tabService Report Document Item` srd"
+			" join `tabService Report` sr on sr.name=srd.parent"
+			" join `tabService Request` req on req.name=sr.service_request"
+			" where srd.custom_attachment=`tabCustom Attachment`.name"
+			" and req.owner=%(user)s)"
+		)
+	# Office Manager / Chief Accountant: broad read access
+	if roles & {"Office Manager", "Chief Accountant"}:
+		# No extra filters for these roles
+		return None
 
-    if not conds:
-        return "1=0"
-    return "(" + ") or (".join(conds) + ")"
+	if not conds:
+		return "1=0"
+	return "(" + ") or (".join(conds) + ")"
 
 
 def get_permission_query_conditions(user: str | None = None) -> str | None:
-    user = user or frappe.session.user
-    return _pgc_for_custom_attachment(user)
+	user = user or frappe.session.user
+	return _pgc_for_custom_attachment(user)
 
 
 def has_permission(doc, user: str | None = None) -> bool:
-    user = user or frappe.session.user
-    roles = set(frappe.get_roles(user))
-    if "System Manager" in roles:
-        return True
-    if "Office Manager" in roles:
-        return True
-    if "Chief Accountant" in roles:
-        return True
-    if doc.owner == user:
-        return True
-    # Project Manager: via project manager of linked Service Report -> Service Request
-    if "Project Manager" in roles:
-        pm = frappe.db.sql(
-            """
-        select sp.project_manager
+	user = user or frappe.session.user
+	roles = set(frappe.get_roles(user))
+	if roles & {"System Manager", "Office Manager", "Chief Accountant"}:
+		return True
+	if doc.owner == user:
+		return True
+	info = frappe.db.sql(
+		"""
+        select sp.project_manager, req.assigned_to, req.owner
         from `tabService Report Document Item` srd
         join `tabService Report` sr on sr.name = srd.parent
         join `tabService Request` req on req.name = sr.service_request
-        join `tabService Project` sp on sp.name = req.project
-        where srd.custom_attachment=%s limit 1
+        left join `tabService Project` sp on sp.name = req.project
+        where srd.custom_attachment=%s
+        limit 1
         """,
-            (doc.name,),
-        )
-        if pm and pm[0][0] == user:
-            return True
-    # Service Engineer: assignee of parent request
-    if "Service Engineer" in roles:
-        assignee = frappe.db.sql(
-            """
-        select req.assigned_to
-        from `tabService Report Document Item` srd
-        join `tabService Report` sr on sr.name = srd.parent
-        join `tabService Request` req on req.name = sr.service_request
-        where srd.custom_attachment=%s limit 1
-        """,
-            (doc.name,),
-        )
-        if assignee and assignee[0][0] == user:
-            return True
-    # Client: owner of parent request
-    if "Client" in roles:
-        owner = frappe.db.sql(
-            """
-        select req.owner
-        from `tabService Report Document Item` srd
-        join `tabService Report` sr on sr.name = srd.parent
-        join `tabService Request` req on req.name = sr.service_request
-        where srd.custom_attachment=%s limit 1
-        """,
-            (doc.name,),
-        )
-        if owner and owner[0][0] == user:
-            return True
-    return False
+		(doc.name,),
+		as_dict=True,
+	)
+	if not info:
+		return False
+	row = info[0]
+	if "Project Manager" in roles and row.project_manager == user:
+		return True
+	if "Service Engineer" in roles and row.assigned_to == user:
+		return True
+	if "Client" in roles and row.owner == user:
+		return True
+	return False
 
 
 class CustomAttachment(Document):
-    # Google Drive sync removed by request. No background syncing is performed.
-    pass
+	# Google Drive sync removed by request. No background syncing is performed.
+	pass

--- a/ferum_custom/ferum_custom/doctype/invoice/invoice.py
+++ b/ferum_custom/ferum_custom/doctype/invoice/invoice.py
@@ -72,6 +72,9 @@ except Exception:
 			pass
 
 
+from ferum_custom.utils import get_emails_by_roles
+
+
 class Invoice(Document):
 	def after_insert(self):
 		self.notify_on_subcontractor_invoice()
@@ -97,22 +100,11 @@ class Invoice(Document):
 			recipients: set[str] = set()
 			settings = _get_settings()
 			roles = ["Chief Accountant", "System Manager"]
-			if settings and getattr(settings, "invoice_notification_roles", None):
-				roles = [r.role for r in settings.invoice_notification_roles]
+			if settings and hasattr(settings, "invoice_notification_roles"):
+				roles = [r.get("link_name") or r.get("value") for r in settings.invoice_notification_roles]
 
 			if roles:
-				user_ids = frappe.get_all(
-					"Has Role",
-					filters={"role": ["in", roles], "parenttype": "User"},
-					pluck="parent",
-				)
-				if user_ids:
-					for u in frappe.db.get_all(
-						"User",
-						filters={"name": ["in", user_ids]},
-						fields=["name", "email"],
-					):
-						recipients.add(u.email or u.name)
+				recipients.update(get_emails_by_roles(roles))
 			if recipients:
 				frappe.sendmail(
 					recipients=list(recipients),

--- a/ferum_custom/ferum_custom/doctype/service_request/service_request.py
+++ b/ferum_custom/ferum_custom/doctype/service_request/service_request.py
@@ -5,6 +5,20 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import add_days, add_to_date, getdate, nowdate
 
+from ferum_custom.utils import get_emails_by_roles
+
+
+def _get_pm_email(project: str) -> str | None:
+	pm_info = frappe.db.get_value(
+		"Service Project",
+		project,
+		["project_manager", "project_manager.email"],
+		as_dict=True,
+	)
+	if not pm_info:
+		return None
+	return pm_info.get("project_manager.email") or pm_info.get("project_manager")
+
 
 class ServiceRequest(Document):
 	def after_insert(self) -> None:
@@ -101,15 +115,7 @@ class ServiceRequest(Document):
 			return
 
 		try:
-			pm_info = frappe.db.get_value(
-				"Service Project",
-				self.project,
-				["project_manager", "project_manager.email"],
-				as_dict=True,
-			)
-			if not pm_info:
-				return
-			email = pm_info.get("project_manager.email") or pm_info.get("project_manager")
+			email = _get_pm_email(self.project)
 			if not email:
 				return
 			frappe.sendmail(
@@ -149,35 +155,14 @@ def send_sla_breach_notifications(service_request_name: str, message: str) -> No
 
 	try:
 		sr = frappe.get_doc("Service Request", service_request_name)
-
 		recipients: set[str] = set()
 
-		# Project manager assigned to the related Service Project
 		if sr.project:
-			pm_info = frappe.db.get_value(
-				"Service Project",
-				sr.project,
-				["project_manager", "project_manager.email"],
-				as_dict=True,
-			)
-			if pm_info:
-				pm_email = pm_info.get("project_manager.email") or pm_info.get("project_manager")
-				if pm_email:
-					recipients.add(pm_email)
+			pm_email = _get_pm_email(sr.project)
+			if pm_email:
+				recipients.add(pm_email)
 
-		# All Office Managers in the system
-		office_manager_ids = frappe.get_all(
-			"Has Role",
-			filters={"role": "Office Manager", "parenttype": "User"},
-			pluck="parent",
-		)
-		if office_manager_ids:
-			for om in frappe.db.get_all(
-				"User",
-				filters={"name": ["in", office_manager_ids]},
-				fields=["name", "email"],
-			):
-				recipients.add(om.email or om.name)
+		recipients.update(get_emails_by_roles(["Office Manager"]))
 
 		if recipients:
 			frappe.sendmail(

--- a/ferum_custom/ferum_custom/utils.py
+++ b/ferum_custom/ferum_custom/utils.py
@@ -1,0 +1,25 @@
+from collections.abc import Sequence
+
+import frappe
+
+
+def get_emails_by_roles(roles: Sequence[str]) -> list[str]:
+	"""Return user emails for any of the given roles.
+
+	If a user has no email set, their username is used instead.
+	"""
+	if not roles:
+		return []
+	user_ids = frappe.get_all(
+		"Has Role",
+		filters={"role": ["in", list(roles)], "parenttype": "User"},
+		pluck="parent",
+	)
+	if not user_ids:
+		return []
+	users = frappe.get_all(
+		"User",
+		filters={"name": ["in", user_ids]},
+		fields=["name", "email"],
+	)
+	return [u.get("email") or u["name"] for u in users]

--- a/ferum_custom/fixtures/report.json
+++ b/ferum_custom/fixtures/report.json
@@ -55,7 +55,7 @@
     "module": "Ferum Custom",
     "report_type": "Query Report",
     "is_standard": "No",
-    "query": "SELECT p.name AS \"Project:Link/Service Project:150\", COALESCE(SUM(CASE WHEN i.counterparty_type='Customer' AND i.status!='Cancelled' THEN i.amount END),0) AS \"Customer Invoices:Currency:150\", COALESCE(SUM(CASE WHEN i.counterparty_type='Subcontractor' AND i.status!='Cancelled' THEN i.amount END),0) AS \"Subcontractor Invoices:Currency:150\", COALESCE(SUM(CASE WHEN i.counterparty_type='Customer' AND i.status!='Cancelled' THEN i.amount END),0) - COALESCE(SUM(CASE WHEN i.counterparty_type='Subcontractor' AND i.status!='Cancelled' THEN i.amount END),0) AS \"Profit:Currency:150\" FROM `tabService Project` p LEFT JOIN `tabInvoice` i ON i.project = p.name GROUP BY p.name ORDER BY p.modified DESC",
+      "query": "WITH invoice_summary AS (SELECT project, SUM(CASE WHEN counterparty_type='Customer' AND status!='Cancelled' THEN amount ELSE 0 END) AS customer_invoices, SUM(CASE WHEN counterparty_type='Subcontractor' AND status!='Cancelled' THEN amount ELSE 0 END) AS subcontractor_invoices FROM `tabInvoice` GROUP BY project) SELECT p.name AS \"Project:Link/Service Project:150\", COALESCE(s.customer_invoices,0) AS \"Customer Invoices:Currency:150\", COALESCE(s.subcontractor_invoices,0) AS \"Subcontractor Invoices:Currency:150\", COALESCE(s.customer_invoices,0) - COALESCE(s.subcontractor_invoices,0) AS \"Profit:Currency:150\" FROM `tabService Project` p LEFT JOIN invoice_summary s ON s.project = p.name GROUP BY p.name, p.modified ORDER BY p.modified DESC",
     "roles": [
       {
         "doctype": "Report Perm",
@@ -79,7 +79,7 @@
     "module": "Ferum Custom",
     "report_type": "Query Report",
     "is_standard": "No",
-    "query": "SELECT name, status, priority, modified FROM `tabService Request` WHERE IFNULL(assigned_to, '') = '' AND status != 'Closed' ORDER BY modified DESC",
+      "query": "SELECT name, status, priority, modified FROM `tabService Request` WHERE assigned_to IS NULL AND status != 'Closed' ORDER BY modified DESC",
     "roles": [
       { "doctype": "Report Perm", "role": "System Manager" },
       { "doctype": "Report Perm", "role": "Office Manager" }


### PR DESCRIPTION
## Summary
- restructure Project Profitability and Unassigned Service Requests queries
- centralize email lookups and project manager resolution
- streamline custom attachment permission checks

## Testing
- `pre-commit run --files ferum_custom/ferum_custom/utils.py ferum_custom/ferum_custom/doctype/invoice/invoice.py ferum_custom/ferum_custom/doctype/service_request/service_request.py ferum_custom/ferum_custom/doctype/custom_attachment/custom_attachment.py ferum_custom/fixtures/report.json`
- `pytest` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_68c8188eef3883289123fe7f7bd55812