### PR TITLE
Refine workspaces and restrict client desk access

### DIFF
--- a/ferum_custom/fixtures/role.json
+++ b/ferum_custom/fixtures/role.json
@@ -3,5 +3,5 @@
   { "doctype": "Role", "name": "Chief Accountant", "role_name": "Chief Accountant", "desk_access": 1 },
   { "doctype": "Role", "name": "Service Engineer", "role_name": "Service Engineer", "desk_access": 1 },
   { "doctype": "Role", "name": "Project Manager", "role_name": "Project Manager", "desk_access": 1 },
-  { "doctype": "Role", "name": "Client", "role_name": "Client", "desk_access": 1 }
+  { "doctype": "Role", "name": "Client", "role_name": "Client", "desk_access": 0 }
 ]

--- a/ferum_custom/workspace/administration/administration.json
+++ b/ferum_custom/workspace/administration/administration.json
@@ -7,7 +7,7 @@
   "content": [
     { "type": "chart", "chart_name": "Open Service Requests by Status" },
     { "type": "chart", "chart_name": "Invoices by Project" },
-    { "type": "shortcut", "label": "Overdue Service Requests", "link_to": "List/Service Request?status=Open" },
+    { "type": "shortcut", "label": "Open Service Requests", "link_to": "List/Service Request?status=Open" },
     { "type": "shortcut", "label": "Income Statement", "link_to": "query-report/Income Statement" }
   ]
 }

--- a/ferum_custom/workspace/client/client.json
+++ b/ferum_custom/workspace/client/client.json
@@ -8,8 +8,6 @@
   ],
   "doctype": "Workspace",
   "content": [
-    { "type": "shortcut", "label": "New Service Request", "link_to": "/portal/new-request" },
-    { "type": "shortcut", "label": "My Requests", "link_to": "List/Service Request" },
-    { "type": "shortcut", "label": "My Invoices", "link_to": "List/Invoice" }
+    { "type": "shortcut", "label": "New Service Request", "link_to": "/portal/new-request" }
   ]
 }

--- a/ferum_custom/workspace/my_requests/my_requests.json
+++ b/ferum_custom/workspace/my_requests/my_requests.json
@@ -7,9 +7,9 @@
   ],
   "doctype": "Workspace",
   "content": [
-    { "type": "shortcut", "label": "Service Requests", "link_to": "List/Service Request" },
+    { "type": "shortcut", "label": "All My Requests", "link_to": "List/Service Request?assigned_to=me" },
     { "type": "shortcut", "label": "My Open Requests", "link_to": "List/Service Request?status=Open&assigned_to=me" },
-    { "type": "shortcut", "label": "My Reports", "link_to": "List/Service Report" },
+    { "type": "shortcut", "label": "My Reports", "link_to": "List/Service Report?owner=me" },
     { "type": "shortcut", "label": "New Service Report", "link_to": "Form/Service Report/New Service Report" }
   ]
 }


### PR DESCRIPTION
## Summary
- Retitle shortcut to open service requests in Administration workspace
- Show only engineer-related items in My Requests workspace
- Remove insecure links and disable Desk access for Client role

## Testing
- `pre-commit run --files ferum_custom/workspace/administration/administration.json ferum_custom/workspace/my_requests/my_requests.json ferum_custom/workspace/client/client.json ferum_custom/fixtures/role.json`

------
https://chatgpt.com/codex/tasks/task_e_68c81b79199483289c2244af2a84e25b