### PR TITLE
Add names to dashboard chart fixtures

### DIFF
--- a/ferum_custom/fixtures/dashboard_chart.json
+++ b/ferum_custom/fixtures/dashboard_chart.json
@@ -1,6 +1,7 @@
 [
   {
     "doctype": "Dashboard Chart",
+    "name": "Open Service Requests by Status",
     "is_standard": 1,
     "module": "Ferum Custom",
     "chart_name": "Open Service Requests by Status",
@@ -15,6 +16,7 @@
   },
   {
     "doctype": "Dashboard Chart",
+    "name": "Invoices by Project",
     "is_standard": 1,
     "module": "Ferum Custom",
     "chart_name": "Invoices by Project",

--- a/ferum_custom/fixtures/dashboard_chart.json
+++ b/ferum_custom/fixtures/dashboard_chart.json
@@ -1,7 +1,7 @@
 [
   {
     "doctype": "Dashboard Chart",
-    "name": "Open Service Requests by Status",
+    "name": "open-service-requests-by-status",
     "is_standard": 1,
     "module": "Ferum Custom",
     "chart_name": "Open Service Requests by Status",


### PR DESCRIPTION
## Summary
- add explicit names to dashboard chart fixtures so they can be imported during installation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c83c0cbc448328aa2c9290b241fb72