### PR TITLE
Fix dashboard chart fixtures to be non-standard

### DIFF
--- a/ferum_custom/fixtures/dashboard_chart.json
+++ b/ferum_custom/fixtures/dashboard_chart.json
@@ -2,7 +2,7 @@
   {
     "doctype": "Dashboard Chart",
     "name": "open-service-requests-by-status",
-    "is_standard": 1,
+    "is_standard": 0,
     "module": "Ferum Custom",
     "chart_name": "Open Service Requests by Status",
     "chart_type": "Group By",
@@ -17,7 +17,7 @@
   {
     "doctype": "Dashboard Chart",
     "name": "Invoices by Project",
-    "is_standard": 1,
+    "is_standard": 0,
     "module": "Ferum Custom",
     "chart_name": "Invoices by Project",
     "chart_type": "Group By",


### PR DESCRIPTION
## Summary
- update dashboard chart fixtures so they are marked as non-standard, allowing installation of the app

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c83e18c6d48328a1e086769685b8d9