### PR TITLE
fix: add aggregate function for invoice dashboard chart

### DIFF
--- a/ferum_custom/fixtures/dashboard_chart.json
+++ b/ferum_custom/fixtures/dashboard_chart.json
@@ -28,6 +28,7 @@
     "value_based_on": "amount",
     "filters_json": "[]",
     "is_public": 1,
-    "timeseries": 0
+    "timeseries": 0,
+    "aggregate_function_based_on": "amount"
   }
 ]


### PR DESCRIPTION
## Summary
- add the required aggregate_function_based_on field to the Invoices by Project dashboard chart fixture

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c84005503c8328b7627345feb64eb5