### PR TITLE
Add lightweight Customer DocType

### DIFF
--- a/ferum_custom/ferum_custom/doctype/customer/customer.json
+++ b/ferum_custom/ferum_custom/doctype/customer/customer.json
@@ -1,0 +1,61 @@
+{
+  "name": "Customer",
+  "doctype": "DocType",
+  "module": "Ferum Custom",
+  "autoname": "field:customer_name",
+  "fields": [
+    {
+      "fieldname": "customer_name",
+      "fieldtype": "Data",
+      "label": "Customer Name",
+      "reqd": 1,
+      "unique": 1,
+      "in_list_view": 1
+    },
+    {
+      "fieldname": "email",
+      "fieldtype": "Data",
+      "label": "Email",
+      "options": "Email"
+    },
+    {
+      "fieldname": "phone",
+      "fieldtype": "Data",
+      "label": "Phone"
+    },
+    {
+      "fieldname": "address",
+      "fieldtype": "Small Text",
+      "label": "Address"
+    },
+    {
+      "fieldname": "notes",
+      "fieldtype": "Text",
+      "label": "Notes"
+    }
+  ],
+  "permissions": [
+    {
+      "role": "System Manager",
+      "read": 1,
+      "write": 1,
+      "create": 1,
+      "delete": 1
+    },
+    {
+      "role": "Project Manager",
+      "read": 1,
+      "write": 1,
+      "create": 1
+    },
+    {
+      "role": "Office Manager",
+      "read": 1,
+      "write": 1
+    },
+    {
+      "role": "Service Engineer",
+      "read": 1
+    }
+  ]
+}

--- a/ferum_custom/ferum_custom/doctype/customer/customer.py
+++ b/ferum_custom/ferum_custom/doctype/customer/customer.py
@@ -1,0 +1,19 @@
+"""Lightweight Customer DocType used for tests and demo data.
+
+This app is designed to run without the full ERPNext dependency tree, but
+several doctypes – such as Service Object and Service Request – link to a
+Customer record.  The frappe test runner instantiates Customer documents in the
+fixtures and automated tests, so we provide a minimal implementation here that
+covers the required fields and permissions without introducing heavy upstream
+coupling.
+"""
+
+from __future__ import annotations
+
+from frappe.model.document import Document
+
+
+class Customer(Document):
+    """Simple customer master used across custom doctypes."""
+
+    pass


### PR DESCRIPTION
## Summary
- add a minimal Customer DocType so linked records and tests can run without the ERPNext module
- provide a simple Document subclass for the custom Customer DocType

## Testing
- python -m compileall ferum_custom/ferum_custom/doctype/customer/customer.py

------
https://chatgpt.com/codex/tasks/task_e_68c846d79a508328b5b7a31594b10ca7