### PR TITLE
Add customer group and territory fields to Customer

### DIFF
--- a/ferum_custom/ferum_custom/doctype/customer/customer.json
+++ b/ferum_custom/ferum_custom/doctype/customer/customer.json
@@ -20,7 +20,7 @@
     },
     {
       "fieldname": "phone",
-      "fieldtype": "Data",
+      "fieldtype": "Phone",
       "label": "Phone"
     },
     {
@@ -32,6 +32,18 @@
       "fieldname": "notes",
       "fieldtype": "Text",
       "label": "Notes"
+    },
+    {
+      "fieldname": "customer_group",
+      "fieldtype": "Link",
+      "label": "Customer Group",
+      "options": "Customer Group"
+    },
+    {
+      "fieldname": "territory",
+      "fieldtype": "Link",
+      "label": "Territory",
+      "options": "Territory"
     }
   ],
   "permissions": [

--- a/ferum_custom/ferum_custom/doctype/customer/customer.py
+++ b/ferum_custom/ferum_custom/doctype/customer/customer.py
@@ -1,7 +1,7 @@
 """Lightweight Customer DocType used for tests and demo data.
 
 This app is designed to run without the full ERPNext dependency tree, but
-several doctypes – such as Service Object and Service Request – link to a
+several doctypes - such as Service Object and Service Request - link to a
 Customer record.  The frappe test runner instantiates Customer documents in the
 fixtures and automated tests, so we provide a minimal implementation here that
 covers the required fields and permissions without introducing heavy upstream
@@ -14,6 +14,12 @@ from frappe.model.document import Document
 
 
 class Customer(Document):
-    """Simple customer master used across custom doctypes."""
+	"""Simple customer master used across custom doctypes."""
 
-    pass
+	customer_name: str
+	email: str | None
+	phone: str | None
+	address: str | None
+	notes: str | None
+	customer_group: str | None
+	territory: str | None


### PR DESCRIPTION
## Summary
- fix the Customer DocType module docstring and add type hints for document fields
- add customer_group and territory link fields and switch the phone field to the Phone type

## Testing
- uv tool run pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68c84a9a4dd88328a22caa1691a9fd3f