### PR TITLE
Secure save_integrations endpoint

### DIFF
--- a/ferum_custom/api/admin.py
+++ b/ferum_custom/api/admin.py
@@ -2,25 +2,29 @@ import frappe
 
 
 @frappe.whitelist()
-def save_integrations(telegram_chat_id: str | None = None,
-                      telegram_token: str | None = None,
-                      drive_root_id: str | None = None) -> dict:
+def save_integrations(
+    telegram_chat_id: str | None = None,
+    telegram_token: str | None = None,
+    drive_root_id: str | None = None,
+) -> dict:
     """Persist integration settings into Ferum Custom Settings singleton.
 
     Only updates provided fields. Returns the saved subset.
     """
+    frappe.only_for("System Manager")
+
     settings = frappe.get_single("Ferum Custom Settings")
     updated: dict[str, str] = {}
 
-    if telegram_chat_id:
+    if telegram_chat_id is not None:
         settings.telegram_default_chat_id = telegram_chat_id
         updated["telegram_default_chat_id"] = telegram_chat_id
 
-    if telegram_token:
+    if telegram_token is not None:
         settings.telegram_bot_token = telegram_token
         # do not include token in response
 
-    if drive_root_id:
+    if drive_root_id is not None:
         settings.google_drive_root_folder_id = drive_root_id
         updated["google_drive_root_folder_id"] = drive_root_id
 


### PR DESCRIPTION
## Summary
- limit the save_integrations API to System Managers to prevent privilege escalation
- allow empty integration values to be persisted so settings can be cleared through the API

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'frappe')*


------
https://chatgpt.com/codex/tasks/task_e_68d12a31a698832886780eeac62c013b