### PR TITLE
Add lightweight frappe shim for tests

### DIFF
--- a/ferum_custom/ferum_custom/doctype/service_request/service_request.py
+++ b/ferum_custom/ferum_custom/doctype/service_request/service_request.py
@@ -22,6 +22,10 @@ def _get_pm_email(project: str) -> str | None:
 
 
 class ServiceRequest(Document):
+	def before_insert(self) -> None:
+		if not self.status:
+			self.status = "Open"
+
 	def after_insert(self) -> None:
 		"""Notify the project manager about the new request.
 

--- a/ferum_custom/tests/conftest.py
+++ b/ferum_custom/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Pytest configuration for the repository tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the repository root (which contains the lightweight ``frappe`` test
+# double) is on ``sys.path`` even when pytest is executed via the shim entry
+# point that lives outside of the project directory.
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1,0 +1,371 @@
+"""Lightweight in-memory Frappe test double.
+
+This module provides a very small subset of the Frappe API that is required by
+the unit tests that ship with this kata.  The real Frappe framework is far too
+heavy to install in the execution environment used for the exercises, so the
+tests interact with this shim instead.  Only the behaviour that is exercised by
+the tests is implemented which keeps the surface area intentionally tiny while
+still feeling familiar to anyone who has used Frappe before.
+"""
+
+from __future__ import annotations
+
+import copy
+import datetime as _dt
+import importlib
+import traceback
+from typing import Any, MutableMapping
+
+__all__ = [
+        "Document",
+        "ValidationError",
+        "_",
+        "db",
+        "enqueue",
+        "get_all",
+        "get_doc",
+        "get_list",
+        "get_roles",
+        "log_error",
+        "logger",
+        "msgprint",
+        "new_doc",
+        "sendmail",
+        "session",
+        "set_user",
+        "throw",
+        "whitelist",
+]
+
+
+class ValidationError(Exception):
+        """Exception raised by :func:`throw`."""
+
+
+def _(text: str) -> str:
+        """Translate text.  The test double simply returns the text unchanged."""
+
+        return text
+
+
+def throw(message: str) -> None:
+        raise ValidationError(message)
+
+
+def msgprint(message: str) -> None:  # pragma: no cover - side effect only
+        """Display a message to the user (no-op in the shim)."""
+
+
+def log_error(message: str, title: str | None = None) -> None:  # pragma: no cover - side effect only
+        """Record an error message.  The shim stores it in memory for introspection."""
+
+        _error_log.append((title, message))
+
+
+def sendmail(*_, **__):  # pragma: no cover - transport side effect only
+        """Pretend to send an email."""
+
+
+def enqueue(*_, **__):  # pragma: no cover - background job side effect only
+        """Pretend to enqueue a background job."""
+
+
+def whitelist(arg: Any | None = None, **__: Any):
+        """Decorator used by Frappe to expose functions via RPC."""
+
+        def decorator(func):
+                return func
+
+        if callable(arg):
+                return decorator(arg)
+        return decorator
+
+
+def get_traceback() -> str:
+        return "".join(traceback.format_exception(*traceback.sys.exc_info()))
+
+
+class _Logger:
+        def info(self, *_: Any, **__: Any) -> None:  # pragma: no cover - diagnostics only
+                pass
+
+        def warning(self, *_: Any, **__: Any) -> None:  # pragma: no cover - diagnostics only
+                pass
+
+        def exception(self, *_: Any, **__: Any) -> None:  # pragma: no cover - diagnostics only
+                pass
+
+
+def logger() -> _Logger:  # pragma: no cover - diagnostics only
+        return _Logger()
+
+
+class _Session:
+        user: str = "Administrator"
+
+
+session = _Session()
+
+_user_roles: dict[str, list[str]] = {"Administrator": ["System Manager"]}
+_error_log: list[tuple[str | None, str]] = []
+
+
+def set_user(user: str) -> None:
+        session.user = user
+
+
+def get_roles(user: str | None = None) -> list[str]:
+        user = user or session.user
+        return list(_user_roles.get(user, []))
+
+
+def add_user_role(user: str, role: str) -> None:
+        roles = _user_roles.setdefault(user, [])
+        if role not in roles:
+                roles.append(role)
+
+
+def scrub(value: str) -> str:
+        return value.replace(" ", "_").replace("/", "_").lower()
+
+
+def _guess_doctype(module: str, class_name: str) -> str:
+        if ".doctype." in module:
+                slug = module.split(".doctype.", 1)[1].split(".", 1)[0]
+                return " ".join(part.capitalize() for part in slug.split("_"))
+        # Fall back to the class name when we cannot derive it from the module
+        return " ".join(_split_camel_case(class_name))
+
+
+def _split_camel_case(name: str) -> list[str]:
+        parts: list[str] = []
+        start = 0
+        for index, char in enumerate(name):
+                if index and char.isupper():
+                        parts.append(name[start:index])
+                        start = index
+        parts.append(name[start:])
+        return [part.capitalize() for part in parts if part]
+
+
+_doctype_registry: dict[str, type["Document"]] = {}
+
+
+def _register_doctype(doctype: str, cls: type["Document"]) -> None:
+        _doctype_registry[doctype] = cls
+
+
+def _get_doctype_class(doctype: str) -> type["Document"] | None:
+        return _doctype_registry.get(doctype)
+
+
+def _load_doctype_module(doctype: str) -> None:
+        if _get_doctype_class(doctype):
+                return
+        slug = scrub(doctype)
+        module_path = f"ferum_custom.ferum_custom.doctype.{slug}.{slug}"
+        try:
+                importlib.import_module(module_path)
+        except ModuleNotFoundError:
+                # Not all doctypes are implemented in the repository.  Those
+                # missing ones fall back to a generic Document implementation.
+                pass
+
+
+class _Database:
+        def __init__(self) -> None:
+                self.reset()
+
+        def reset(self) -> None:
+                self._data: dict[str, dict[str, dict[str, Any]]] = {}
+                self._autoname: dict[str, int] = {}
+                # Bootstrap core records required by the tests
+                self.upsert(
+                        "User",
+                        "Administrator",
+                        {
+                                "email": "administrator@example.com",
+                                "first_name": "Administrator",
+                                "user_type": "System User",
+                                "enabled": 1,
+                        },
+                )
+                add_user_role("Administrator", "System Manager")
+                self.upsert("Role", "Client", {"desk_access": 0})
+
+        # -- storage helpers -------------------------------------------------
+        def upsert(self, doctype: str, name: str, data: MutableMapping[str, Any]) -> None:
+                stored = copy.deepcopy(dict(data))
+                stored["name"] = name
+                stored.setdefault("owner", "Administrator")
+                self._data.setdefault(doctype, {})[name] = stored
+
+        def generate_name(self, doctype: str) -> str:
+                prefix = "".join(part[0].upper() for part in doctype.split() if part)
+                counter = self._autoname.setdefault(doctype, 0) + 1
+                self._autoname[doctype] = counter
+                return f"{prefix}-{counter:05d}" if prefix else f"AUTO-{counter:05d}"
+
+        def insert(self, doc: "Document") -> None:
+                if not doc.name:
+                        doc.name = self.generate_name(doc.doctype)
+                self._data.setdefault(doc.doctype, {})[doc.name] = doc._snapshot()
+
+        def update(self, doc: "Document") -> None:
+                if doc.name not in self._data.get(doc.doctype, {}):
+                        raise ValidationError(f"Document {doc.doctype} {doc.name} does not exist")
+                self._data[doc.doctype][doc.name] = doc._snapshot()
+
+        def get_doc_data(self, doctype: str, name_or_filters: Any) -> dict[str, Any] | None:
+                if isinstance(name_or_filters, str):
+                        record = self._data.get(doctype, {}).get(name_or_filters)
+                        return copy.deepcopy(record) if record else None
+                if isinstance(name_or_filters, dict):
+                        for record in self._data.get(doctype, {}).values():
+                                if _match_filters(record, name_or_filters):
+                                        return copy.deepcopy(record)
+                        return None
+                raise TypeError("name_or_filters must be a string or mapping")
+
+        # -- query helpers ---------------------------------------------------
+        def exists(self, doctype: str, filters: Any) -> bool:
+                return self.get_doc_name(doctype, filters) is not None
+
+        def get_doc_name(self, doctype: str, filters: Any) -> str | None:
+                if isinstance(filters, str):
+                        return filters if filters in self._data.get(doctype, {}) else None
+                if isinstance(filters, dict):
+                        for name, record in self._data.get(doctype, {}).items():
+                                if _match_filters(record, filters):
+                                        return name
+                return None
+
+        def get_value(
+                self,
+                doctype: str,
+                filters: Any,
+                fieldname: str | Iterable[str] | None = None,
+                *,
+                as_dict: bool = False,
+        ) -> Any:
+                record = self.get_doc_data(doctype, filters)
+                if not record:
+                        return None
+                if fieldname is None:
+                        return record.get("name")
+                if isinstance(fieldname, (list, tuple)):
+                        result = {field: record.get(field) for field in fieldname}
+                        return result if as_dict else tuple(result.values())
+                value = record.get(fieldname)
+                if as_dict:
+                        return {fieldname: value}
+                return value
+
+        def set_value(self, doctype: str, name: str, field: Any, value: Any | None = None) -> None:
+                record = self._data.get(doctype, {}).get(name)
+                if not record:
+                        raise ValidationError(f"Document {doctype} {name} not found")
+                updates: dict[str, Any]
+                if isinstance(field, dict):
+                        updates = field
+                else:
+                        updates = {field: value}
+                record.update(copy.deepcopy(updates))
+                record["modified"] = _dt.datetime.now()
+
+        def get_all(
+                self,
+                doctype: str,
+                *,
+                filters: dict[str, Any] | None = None,
+                pluck: str | None = None,
+        ) -> list[Any]:
+                records = []
+                for record in self._data.get(doctype, {}).values():
+                        if filters and not _match_filters(record, filters):
+                                continue
+                        if pluck:
+                                records.append(record.get(pluck))
+                        else:
+                                records.append(copy.deepcopy(record))
+                return records
+
+        def get_list(
+                self,
+                doctype: str,
+                *,
+                filters: dict[str, Any] | None = None,
+                pluck: str | None = None,
+        ) -> list[Any]:
+                return self.get_all(doctype, filters=filters or {}, pluck=pluck)
+
+        def sql(
+                self,
+                *_: Any,
+                **__: Any,
+        ) -> list[Any]:  # pragma: no cover - simple stub
+                return []
+
+
+def _match_filters(record: MutableMapping[str, Any], filters: dict[str, Any]) -> bool:
+        for field, expected in filters.items():
+                value = record.get(field)
+                if isinstance(expected, (list, tuple)) and expected:
+                        operator = expected[0]
+                        operand = expected[1] if len(expected) > 1 else None
+                        if operator == "in":
+                                if value not in set(operand or []):
+                                        return False
+                        elif operator == "not in":
+                                if value in set(operand or []):
+                                        return False
+                        else:
+                                raise NotImplementedError(f"Unsupported operator {operator!r}")
+                else:
+                        if value != expected:
+                                return False
+        return True
+
+
+db = _Database()
+
+
+# ``Document`` and helpers are imported at the bottom of the module to avoid
+# circular import issues.  The class lives in ``frappe.model.document`` but the
+# majority of the shim interacts with it via this module.
+from .model.document import Document, get_document_class  # noqa: E402  (import at end of file)
+
+
+def new_doc(doctype: str) -> "Document":
+        _load_doctype_module(doctype)
+        cls = get_document_class(doctype)
+        return cls(doctype=doctype)
+
+
+def get_doc(doctype: str, name_or_filters: Any) -> "Document":
+        _load_doctype_module(doctype)
+        cls = get_document_class(doctype)
+        data = db.get_doc_data(doctype, name_or_filters)
+        if data is None:
+                raise ValidationError(f"Document {doctype} not found")
+        return cls(data=data, doctype=doctype, is_new=False)
+
+
+def get_all(
+        doctype: str,
+        *,
+        filters: dict[str, Any] | None = None,
+        pluck: str | None = None,
+) -> list[Any]:
+        return db.get_all(doctype, filters=filters or {}, pluck=pluck)
+
+
+def get_list(
+        doctype: str,
+        *,
+        filters: dict[str, Any] | None = None,
+        pluck: str | None = None,
+        ignore_permissions: bool | None = None,  # noqa: ARG001 - matches API
+) -> list[Any]:
+        _ = ignore_permissions
+        return db.get_list(doctype, filters=filters or {}, pluck=pluck)

--- a/frappe/model/__init__.py
+++ b/frappe/model/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for ``frappe.model``.

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1,0 +1,219 @@
+"""Minimal :mod:`frappe.model.document` implementation for the tests."""
+
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+from typing import Any
+
+import frappe
+import frappe.utils
+from frappe import _get_doctype_class, _guess_doctype, _register_doctype
+
+
+class DocumentMeta(type):
+        def __new__(mcls, name: str, bases: tuple[type, ...], attrs: dict[str, Any]) -> type:
+                cls = super().__new__(mcls, name, bases, attrs)
+                if not attrs.get("__register__", True):
+                        return cls
+                doctype = attrs.get("doctype") or _guess_doctype(attrs.get("__module__", ""), name)
+                cls.doctype = doctype  # type: ignore[attr-defined]
+                _register_doctype(doctype, cls)  # type: ignore[arg-type]
+                return cls
+
+
+class Document(metaclass=DocumentMeta):
+        """A tiny drop-in stand-in for :class:`frappe.model.document.Document`."""
+
+        __register__ = False  # prevent registration of the base class itself
+
+        def __init__(
+                self,
+                *,
+                data: dict[str, Any] | None = None,
+                doctype: str | None = None,
+                is_new: bool = True,
+        ) -> None:
+                self.doctype = doctype or getattr(self, "doctype")
+                self.name: str | None = None
+                self.owner = frappe.session.user
+                self.docstatus = 0
+                self.creation = frappe.utils.now_datetime()
+                self.modified = self.creation
+                self._is_new = is_new
+                self._original_values: dict[str, Any] = {}
+                if data:
+                        self._load(data)
+                        self._original_values = self._snapshot()
+
+        # -- helpers ---------------------------------------------------------
+        def _load(self, data: dict[str, Any]) -> None:
+                for key, value in data.items():
+                        if key.startswith("_"):
+                                continue
+                        setattr(self, key, self._coerce_value(value))
+
+        def _coerce_value(self, value: Any) -> Any:
+                if isinstance(value, list):
+                        coerced = []
+                        for item in value:
+                                if isinstance(item, dict):
+                                        coerced.append(SimpleNamespace(**item))
+                                else:
+                                        coerced.append(copy.deepcopy(item))
+                        return coerced
+                return copy.deepcopy(value)
+
+        def _snapshot(self) -> dict[str, Any]:
+                state: dict[str, Any] = {}
+                for key, value in self.__dict__.items():
+                        if key.startswith("_"):
+                                continue
+                        if isinstance(value, list):
+                                serialised = []
+                                for item in value:
+                                        if isinstance(item, SimpleNamespace):
+                                                serialised.append(item.__dict__.copy())
+                                        else:
+                                                serialised.append(copy.deepcopy(item))
+                                state[key] = serialised
+                        else:
+                                state[key] = copy.deepcopy(value)
+                return state
+
+        def _current_value(self, field: str) -> Any:
+                value = getattr(self, field, None)
+                if isinstance(value, list):
+                        return [item.__dict__.copy() if isinstance(item, SimpleNamespace) else copy.deepcopy(item) for item in value]
+                return copy.deepcopy(value)
+
+        # -- API -------------------------------------------------------------
+        def __getattr__(self, item: str) -> Any:
+                if item.startswith("_"):
+                        raise AttributeError(item)
+                return None
+
+        def is_new(self) -> bool:
+                        return self._is_new
+
+        def insert(self) -> "Document":
+                if not self.is_new():
+                        return self.save()
+                self.before_insert()
+                self.before_save()
+                self.validate()
+                if not self.name:
+                        if self.doctype == "User" and getattr(self, "email", None):
+                                self.name = self.email
+                        elif self.doctype == "Customer" and getattr(self, "customer_name", None):
+                                self.name = self.customer_name
+                        else:
+                                self.name = frappe.db.generate_name(self.doctype)
+                if not getattr(self, "owner", None):
+                        self.owner = frappe.session.user
+                self.creation = self.creation or frappe.utils.now_datetime()
+                self.modified = self.creation
+                frappe.db.insert(self)
+                self._is_new = False
+                self._original_values = self._snapshot()
+                self.after_insert()
+                self.on_update()
+                return self
+
+        def save(self) -> "Document":
+                if self.is_new():
+                        return self.insert()
+                self.before_save()
+                self.validate()
+                self.modified = frappe.utils.now_datetime()
+                frappe.db.update(self)
+                self.on_update()
+                self._original_values = self._snapshot()
+                return self
+
+        def submit(self) -> "Document":
+                self.docstatus = 1
+                self.before_submit()
+                self.validate()
+                self.modified = frappe.utils.now_datetime()
+                frappe.db.update(self)
+                self.on_submit()
+                self._original_values = self._snapshot()
+                return self
+
+        def reload(self) -> "Document":
+                if not self.name:
+                        raise ValidationError("Cannot reload document without a name")
+                data = frappe.db.get_doc_data(self.doctype, self.name)
+                if not data:
+                        raise ValidationError(f"Document {self.doctype} {self.name} missing")
+                self._load(data)
+                self._is_new = False
+                self._original_values = self._snapshot()
+                return self
+
+        def append(self, field: str, value: dict[str, Any]) -> SimpleNamespace:
+                items = getattr(self, field, None)
+                if items is None:
+                        items = []
+                        setattr(self, field, items)
+                item = SimpleNamespace(**value)
+                items.append(item)
+                return item
+
+        def db_set(self, field: str, value: Any, commit: bool | None = None) -> None:  # noqa: ARG002 - API compat
+                setattr(self, field, value)
+                frappe.db.set_value(self.doctype, self.name, field, value)
+                self._original_values[field] = copy.deepcopy(value)
+
+        def has_value_changed(self, field: str) -> bool:
+                return self._original_values.get(field) != self._current_value(field)
+
+        def has_changed(self, field: str) -> bool:
+                return self.has_value_changed(field)
+
+        def add_comment(self, *_: Any, **__: Any) -> None:  # pragma: no cover - audit trail not needed
+                pass
+
+        def add_roles(self, *roles: str) -> None:
+                if not self.name:
+                        raise ValidationError("User document must be inserted before assigning roles")
+                for role in roles:
+                        frappe.add_user_role(self.name, role)
+
+        # -- hook stubs ------------------------------------------------------
+        def before_insert(self) -> None:  # pragma: no cover - default hook
+                pass
+
+        def after_insert(self) -> None:  # pragma: no cover - default hook
+                pass
+
+        def before_save(self) -> None:  # pragma: no cover - default hook
+                pass
+
+        def before_submit(self) -> None:  # pragma: no cover - default hook
+                pass
+
+        def on_submit(self) -> None:  # pragma: no cover - default hook
+                pass
+
+        def on_update(self) -> None:  # pragma: no cover - default hook
+                pass
+
+        def validate(self) -> None:  # pragma: no cover - default hook
+                pass
+
+
+class GenericDocument(Document):
+        __register__ = False
+
+
+def get_document_class(doctype: str) -> type[Document]:
+        cls = _get_doctype_class(doctype)
+        if cls:
+                return cls  # type: ignore[return-value]
+        return GenericDocument
+
+
+ValidationError = frappe.ValidationError
+

--- a/frappe/tests/__init__.py
+++ b/frappe/tests/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for ``frappe.tests``.

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -1,0 +1,15 @@
+"""Testing helpers mimicking a subset of Frappe's test utilities."""
+
+from __future__ import annotations
+
+import unittest
+
+import frappe
+
+
+class FrappeTestCase(unittest.TestCase):
+        """TestCase base class providing a clean default session."""
+
+        def setUp(self) -> None:  # noqa: D401 - pytest style docstring not required
+                frappe.set_user("Administrator")
+

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -1,0 +1,83 @@
+"""Utility helpers used by the frappe test double."""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import Any
+
+
+def now_datetime() -> _dt.datetime:
+        return _dt.datetime.now()
+
+
+def now() -> _dt.datetime:
+        return now_datetime()
+
+
+def nowdate() -> str:
+        return now_datetime().date().isoformat()
+
+
+def today() -> str:
+        return nowdate()
+
+
+def add_to_date(
+        base: _dt.datetime | str,
+        *,
+        years: int = 0,
+        months: int = 0,
+        days: int = 0,
+        hours: int = 0,
+        minutes: int = 0,
+        seconds: int = 0,
+) -> _dt.datetime:
+        dt = _ensure_datetime(base)
+        # Month arithmetic is intentionally very small in scope; the tests only
+        # rely on the ability to add hours so we fall back to naive month
+        # handling for completeness.
+        month = dt.month - 1 + months
+        year = dt.year + years + month // 12
+        month = month % 12 + 1
+        day = min(dt.day, _days_in_month(year, month))
+        dt = dt.replace(year=year, month=month, day=day)
+        dt += _dt.timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
+        return dt
+
+
+def add_days(base: _dt.datetime | str, count: int) -> _dt.datetime:
+        return _ensure_datetime(base) + _dt.timedelta(days=count)
+
+
+def getdate(value: _dt.datetime | _dt.date | str) -> _dt.date:
+        if isinstance(value, _dt.date) and not isinstance(value, _dt.datetime):
+                return value
+        if isinstance(value, str):
+                return _ensure_datetime(value).date()
+        return value.date()
+
+
+def get_datetime(value: _dt.datetime | str) -> _dt.datetime:
+        return _ensure_datetime(value)
+
+
+def _ensure_datetime(value: _dt.datetime | str) -> _dt.datetime:
+        if isinstance(value, _dt.datetime):
+                return value
+        if isinstance(value, str):
+                try:
+                        return _dt.datetime.fromisoformat(value)
+                except ValueError:
+                        pass
+                return _dt.datetime.strptime(value, "%Y-%m-%d")
+        raise TypeError(f"Unsupported datetime value: {value!r}")
+
+
+def _days_in_month(year: int, month: int) -> int:
+        if month == 12:
+                next_month = _dt.date(year + 1, 1, 1)
+        else:
+                next_month = _dt.date(year, month + 1, 1)
+        current = _dt.date(year, month, 1)
+        return (next_month - current).days
+

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -1,0 +1,8 @@
+"""Background job helpers."""
+
+from __future__ import annotations
+
+
+def enqueue(*_, **__):  # pragma: no cover - background jobs are out of scope
+        return None
+

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -1,0 +1,15 @@
+"""PDF utilities for the frappe shim."""
+
+from __future__ import annotations
+
+
+def get_pdf(html: str) -> bytes:
+        """Return bytes representing the rendered PDF.
+
+        Generating actual PDFs is unnecessary for the unit tests; returning the
+        encoded HTML keeps the behaviour deterministic and sufficient for code
+        that merely verifies that ``get_pdf`` was invoked.
+        """
+
+        return html.encode("utf-8")
+


### PR DESCRIPTION
## Summary
- implement an in-memory frappe test double to satisfy the doctypes exercised by the unit tests
- ensure pytest can import the local frappe package by adding a test-side conftest helper
- default Service Request documents to the Open status during insert so workflow validation mirrors production behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d12edcad2483288542964a9d8b79a0