### PR TITLE
Fix Drive f-string escaping and modernize isinstance checks

### DIFF
--- a/ferum_custom/ferum_custom/integrations/drive.py
+++ b/ferum_custom/ferum_custom/integrations/drive.py
@@ -41,7 +41,8 @@ def _drive_service():
 
 
 def _ensure_folder(drive, name: str, parent_id: str | None) -> str | None:
-	q = f"mimeType='application/vnd.google-apps.folder' and name='{name.replace("'", "\\'")}'"
+	escaped_name = name.replace("'", "\'")
+	q = f"mimeType='application/vnd.google-apps.folder' and name='{escaped_name}'"
 	if parent_id:
 		q += f" and '{parent_id}' in parents"
 	try:

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -253,7 +253,7 @@ class _Database:
                         return None
                 if fieldname is None:
                         return record.get("name")
-                if isinstance(fieldname, (list, tuple)):
+                if isinstance(fieldname, list | tuple):
                         result = {field: record.get(field) for field in fieldname}
                         return result if as_dict else tuple(result.values())
                 value = record.get(fieldname)
@@ -310,7 +310,7 @@ class _Database:
 def _match_filters(record: MutableMapping[str, Any], filters: dict[str, Any]) -> bool:
         for field, expected in filters.items():
                 value = record.get(field)
-                if isinstance(expected, (list, tuple)) and expected:
+                if isinstance(expected, list | tuple) and expected:
                         operator = expected[0]
                         operand = expected[1] if len(expected) > 1 else None
                         if operator == "in":


### PR DESCRIPTION
## Summary
- compute the Drive search query name escape outside the f-string to avoid Python 3.10 syntax issues
- replace tuple arguments in isinstance checks with the | operator in frappe/__init__.py

## Testing
- python -m compileall ferum_custom/ferum_custom/integrations/drive.py frappe/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68d140859e008328aabe475b8720e808